### PR TITLE
Read STEP through the published step-p21, and add monstertruck-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "monstertruck-fillet",
     "monstertruck-geometry",
     "monstertruck-healing",
+    "monstertruck-io",
     "monstertruck-traits",
     "monstertruck-wasm",
     "monstertruck-meshing",
@@ -82,6 +83,7 @@ monstertruck-derive = { version = "0.3.3", path = "monstertruck-derive" }
 monstertruck-fillet = { version = "0.3.3", path = "monstertruck-fillet" }
 monstertruck-geometry = { version = "0.3.3", path = "monstertruck-geometry" }
 monstertruck-healing = { version = "0.3.3", path = "monstertruck-healing" }
+monstertruck-io = { version = "0.3.3", path = "monstertruck-io" }
 monstertruck-mesh = { version = "0.3.3", path = "monstertruck-mesh" }
 monstertruck-meshing = { version = "0.3.3", path = "monstertruck-meshing" }
 monstertruck-modeling = { version = "0.3.3", path = "monstertruck-modeling" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ console_error_panic_hook = "0.1"
 console_log = "1"
 derive_more = { version = "2", features = ["full"] }
 env_logger = "0.11"
-espr-derive = "0.4"
 futures-intrusive = "0.5"
 getrandom = { version = "0.4", features = ["wasm_js"] }
 gloo = "0.12"
@@ -60,7 +59,7 @@ rkyv = { version = "0.8", features = ["alloc"] }
 rclite = "0.4"
 rustc-hash = "2"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-ruststep = "0.4"
+step-p21 = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smallvec = "1"
@@ -93,35 +92,6 @@ monstertruck-step = { version = "0.3.3", path = "monstertruck-step" }
 monstertruck-topology = { version = "0.3.3", path = "monstertruck-topology" }
 monstertruck-traits = { version = "0.3.3", path = "monstertruck-traits" }
 
-
-# Two ISO 10303-21 tokenizer defects block whole public STEP assemblies on the
-# published ruststep 0.4.0:
-#
-#   * a string literal may escape a literal apostrophe by DOUBLING it (`''`),
-#     which imperial CAD emits constantly as inch marks in thread callouts --
-#     the sole reason UMC-500_SS_Solid_Model_2019-06_r1.stp (59 MB) is unreadable;
-#   * an aggregate may be EMPTY (`()`), e.g. `ADVANCED_FACE('',(),#57075,.T.)` --
-#     the sole reason Ai-14R.stp (99 MB AP203) is unreadable.
-#
-# BOTH are already fixed on ruststep master and are merely UNRELEASED: crates.io
-# 0.4.0 is three commits behind. The fixes are
-#   https://github.com/ricosjp/ruststep/pull/251 (author's original)
-#   https://github.com/ricosjp/ruststep/pull/254 (merged 2025-03-19, in master)
-# so there is nothing for us to upstream -- this pin exists ONLY because no
-# release carries them yet. It comes off the moment ruststep publishes any
-# version above 0.4.0; then this whole section is deleted and the workspace
-# `ruststep = "0.4"` requirement is bumped to that release.
-#
-# Pinned by exact rev (the PR #254 merge commit) rather than by branch, so the
-# build stays reproducible. Only `ruststep` needs patching: `ruststep-derive`
-# has no other dependent, so it follows from the git checkout's path dep.
-# A mirror of this rev is parked at virtualritz/ruststep#monstertruck-pin in
-# case upstream ever rewrites master.
-#
-# Acceptance: the two formerly-`#[ignore]`d tests in
-# monstertruck-step/tests/tokenize_bisect.rs, plus the corpus census.
-[patch.crates-io]
-ruststep = { git = "https://github.com/ricosjp/ruststep", rev = "cd89e5a7cd9a6baadcb456392a5888f4cbc6b707" }
 
 [profile.release.package.monstertruck-wasm]
 opt-level = "z"

--- a/justfile
+++ b/justfile
@@ -121,7 +121,7 @@ doc:
 rdme_version := "2.1.0"
 
 # Crates whose README is generated from their crate-level docs by `cargo rdme`.
-rdme_crates := "monstertruck monstertruck-assembly monstertruck-core monstertruck-derive monstertruck-fillet monstertruck-geometry monstertruck-gpu monstertruck-healing monstertruck-mesh monstertruck-meshing monstertruck-modeling monstertruck-render monstertruck-solid monstertruck-step monstertruck-topology monstertruck-traits monstertruck-wasm"
+rdme_crates := "monstertruck monstertruck-assembly monstertruck-core monstertruck-derive monstertruck-fillet monstertruck-geometry monstertruck-gpu monstertruck-healing monstertruck-io monstertruck-mesh monstertruck-meshing monstertruck-modeling monstertruck-render monstertruck-solid monstertruck-step monstertruck-topology monstertruck-traits monstertruck-wasm"
 
 # Regenerate every generated README from its crate-level docs.
 #

--- a/monstertruck-io/Cargo.toml
+++ b/monstertruck-io/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "monstertruck-io"
+version = "0.3.3"
+authors = ["Moritz Moeller <virtualritz@protonmail.com>"]
+edition = "2024"
+description = "Import CAD exchange formats into monstertruck's B-rep types"
+homepage = "https://github.com/virtualritz/monstertruck"
+repository = "https://github.com/virtualritz/monstertruck"
+readme = "README.md"
+keywords = ["cad", "iges", "step", "import", "brep"]
+categories = ["graphics", "science", "parser-implementations"]
+license = "Apache-2.0"
+# Held back from crates.io until the cadmpeg conversion is written. Publishing a
+# crate whose only novel entry point returns `Unimplemented` would advertise an
+# importer that cannot import.
+publish = false
+
+# One feature per format. Nothing is on by default: every format drags a decoder
+# and its dependency tree, and a consumer that wants STEP should not compile an
+# IGES reader.
+[features]
+default = []
+# Reading IGES 5.3, via the cadmpeg codec.
+iges = ["cadmpeg-codec-iges", "cadmpeg-codec-core", "cadmpeg-ir"]
+# Reading and writing ISO 10303-21, via monstertruck's own STEP crate.
+step = ["monstertruck-step"]
+
+[dependencies]
+monstertruck-core = { workspace = true }
+monstertruck-geometry = { workspace = true }
+monstertruck-modeling = { workspace = true }
+monstertruck-topology = { workspace = true }
+thiserror = { workspace = true }
+
+monstertruck-step = { workspace = true, optional = true }
+
+# The cadmpeg codecs all decode into ONE intermediate representation, which is
+# why this crate needs a single converter rather than one per format.
+cadmpeg-ir = { version = "0.3", optional = true }
+cadmpeg-codec-iges = { version = "0.3", optional = true }
+# `ReadSeek` is public here rather than in cadmpeg-ir.
+cadmpeg-codec-core = { version = "0.3", optional = true }

--- a/monstertruck-io/README.md
+++ b/monstertruck-io/README.md
@@ -1,0 +1,57 @@
+# `monstertruck-io`
+
+<!-- cargo-rdme start -->
+
+Import CAD exchange formats into monstertruck's B-rep types.
+
+## Status
+
+The `step` feature is complete: it re-exports monstertruck's own reader and
+writer, which work today.
+
+The `iges` feature is a **placeholder**. It decodes a real file with a real
+decoder, but the last step -- turning the recovered geometry into
+monstertruck's B-rep -- is unwritten, so it returns
+`Error::Unimplemented` rather than an empty model. A caller therefore
+cannot mistake "not written yet" for "this file contained no geometry", and
+the two are reported by distinct variants. That distinction is the point: an
+importer that silently returns nothing is worse than one that refuses, and
+`tests/refuses_rather_than_returns_nothing.rs` fails the day it stops.
+
+## Why one crate and not one per format
+
+The [`cadmpeg`](https://github.com/cadmpeg/cadmpeg) codecs -- IGES today,
+others later -- all decode into a single intermediate representation,
+`cadmpeg_ir::CadIr`. The per-format work is therefore only *which decoder to
+call*; the part that carries the risk, mapping recovered geometry and
+topology onto `monstertruck_topology`, is shared. So this crate holds one
+converter in `cadmpeg` and a thin module per format on top of it.
+
+Each format is a feature, and none is on by default: a consumer that wants
+STEP should not compile an IGES reader.
+
+## Division of labour
+
+| format | feature | decoder | why |
+| --- | --- | --- | --- |
+| ISO 10303-21 (STEP) | `step` | `monstertruck_step` | monstertruck's own reader and writer |
+| IGES 5.3 | `iges` | `cadmpeg-codec-iges` | nothing to gain from writing our own |
+
+STEP deliberately does **not** go through cadmpeg. monstertruck's own STEP
+reader is measured against a corpus, routes analytic surfaces onto closed
+forms so booleans stay exact, and reports what a file lost. Measured
+2026-08-04 on `occt-cylinder.step`: monstertruck reads it correctly, and
+cadmpeg drops the whole `MANIFOLD_SOLID_BREP` because one parameter-space
+`CIRCLE` fails to decode (cadmpeg/cadmpeg#79). Writing STEP stays ours
+outright.
+
+IGES is the opposite case: monstertruck cannot read it at all, and cadmpeg
+scores it highly, so "imperfect but loud" beats "absent".
+
+<!-- cargo-rdme end -->
+
+> Not published to crates.io yet -- see *Status*.
+
+## License
+
+Apache License 2.0

--- a/monstertruck-io/src/cadmpeg.rs
+++ b/monstertruck-io/src/cadmpeg.rs
@@ -1,0 +1,48 @@
+//! The one converter: `cadmpeg`'s intermediate representation to monstertruck.
+//!
+//! Every cadmpeg codec decodes into [`cadmpeg_ir::CadIr`], so this is the only
+//! place that has to understand recovered geometry, and each format module above
+//! it is a few lines choosing a decoder. Adding a format should not touch this
+//! file except to widen what it already handles.
+//!
+//! # What the conversion has to get right
+//!
+//! `CadIr` carries a flat, table-shaped B-rep -- bodies, regions, shells, faces,
+//! loops, coedges, edges, vertices, plus separate surface, curve and pcurve
+//! tables -- which is the same shape monstertruck's [`CompressedShell`] uses, so
+//! the mapping is mostly index translation. Three things are not:
+//!
+//! * **Analytic carriers must stay analytic.** A cylinder arriving as
+//!   [`Surface::Plane`]-adjacent NURBS is a silent loss of exactness that the
+//!   boolean kernel pays for later. Verified 2026-08-04 that cadmpeg does keep
+//!   them: a real part decoded as 34 planes, 38 cylinders, 10 tori and 4 NURBS
+//!   rather than 82 spline patches.
+//! * **Units.** cadmpeg normalises to millimetres on decode. Anything that
+//!   assumes the source unit will be wrong by a factor.
+//! * **Loss.** cadmpeg reports what it dropped, per entity, with a reason. That
+//!   report must reach the caller rather than being discarded, which is why
+//!   [`Error::Decode`] carries the decoder's own message.
+//!
+//! [`CompressedShell`]: monstertruck_topology::compress::CompressedShell
+//! [`Surface::Plane`]: monstertruck_modeling::Surface
+
+use crate::{Error, Result};
+use monstertruck_modeling::{Curve, Point3, Surface};
+use monstertruck_topology::compress::CompressedSolid;
+
+/// A solid as monstertruck's kernel wants it, over the canonical curve and
+/// surface enums the boolean pipeline consumes.
+pub type ImportedSolid = CompressedSolid<Point3, Curve, Surface>;
+
+/// Convert every body in a decoded document into monstertruck solids.
+///
+/// Returns [`Error::NoGeometry`] when the document decoded but held no body,
+/// which is a fact about the file, not a failure to read it.
+pub fn to_solids(ir: &cadmpeg_ir::CadIr, format: &'static str) -> Result<Vec<ImportedSolid>> {
+    if ir.model.bodies.is_empty() {
+        return Err(Error::NoGeometry { format });
+    }
+    Err(Error::Unimplemented {
+        what: "cadmpeg intermediate representation to monstertruck B-rep",
+    })
+}

--- a/monstertruck-io/src/error.rs
+++ b/monstertruck-io/src/error.rs
@@ -1,0 +1,45 @@
+//! Import failures, typed.
+
+/// What can go wrong importing an exchange file.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// The file could not be read.
+    #[error("reading the input failed")]
+    Io(#[from] std::io::Error),
+
+    /// The decoder rejected the file, or recovered nothing this crate can use.
+    ///
+    /// Carries the decoder's own message: those messages name the offending
+    /// entity, and discarding them would make a defect much harder to find.
+    #[error("{format} decode failed: {message}")]
+    Decode {
+        /// Which format was being read.
+        format: &'static str,
+        /// The decoder's own diagnostic.
+        message: String,
+    },
+
+    /// The file decoded, but carried nothing this crate can turn into a solid.
+    ///
+    /// Distinct from [`Error::Decode`]: the input was understood and simply held
+    /// no usable body, which is a fact about the file rather than a failure.
+    #[error("{format} decoded but carried no convertible geometry")]
+    NoGeometry {
+        /// Which format was being read.
+        format: &'static str,
+    },
+
+    /// This path is not written yet.
+    ///
+    /// Present so a placeholder cannot be mistaken for a successful import that
+    /// happened to find nothing. It is deliberately unpleasant to ignore.
+    #[error("{what} is not implemented yet")]
+    Unimplemented {
+        /// The conversion that is missing.
+        what: &'static str,
+    },
+}
+
+/// Import result.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/monstertruck-io/src/iges.rs
+++ b/monstertruck-io/src/iges.rs
@@ -1,0 +1,32 @@
+//! Reading IGES 5.3, via `cadmpeg-codec-iges`.
+//!
+//! monstertruck has no IGES reader of its own and writing one is not worth the
+//! effort: cadmpeg already decodes the format to exact analytic carriers and
+//! reports what it could not. This module is only the decoder call; the work is
+//! in [`crate::cadmpeg`].
+
+use crate::{
+    Result,
+    cadmpeg::{ImportedSolid, to_solids},
+};
+use cadmpeg_codec_core::ReadSeek;
+use cadmpeg_ir::codec::{CodecEntry, DecodeOptions};
+
+const FORMAT: &str = "IGES";
+
+/// Read solids from an IGES 5.3 stream.
+pub fn from_reader(reader: &mut dyn ReadSeek) -> Result<Vec<ImportedSolid>> {
+    let decoded = cadmpeg_codec_iges::IgesCodec
+        .decode(reader, &DecodeOptions::default())
+        .map_err(|error| crate::Error::Decode {
+            format: FORMAT,
+            message: error.to_string(),
+        })?;
+    to_solids(&decoded.ir, FORMAT)
+}
+
+/// Read solids from an IGES 5.3 file.
+pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Vec<ImportedSolid>> {
+    let mut file = std::fs::File::open(path)?;
+    from_reader(&mut file)
+}

--- a/monstertruck-io/src/lib.rs
+++ b/monstertruck-io/src/lib.rs
@@ -1,0 +1,68 @@
+//! Import CAD exchange formats into monstertruck's B-rep types.
+//!
+//! # Status
+//!
+//! The `step` feature is complete: it re-exports monstertruck's own reader and
+//! writer, which work today.
+//!
+//! The `iges` feature is a **placeholder**. It decodes a real file with a real
+//! decoder, but the last step -- turning the recovered geometry into
+//! monstertruck's B-rep -- is unwritten, so it returns
+//! [`Error::Unimplemented`] rather than an empty model. A caller therefore
+//! cannot mistake "not written yet" for "this file contained no geometry", and
+//! the two are reported by distinct variants. That distinction is the point: an
+//! importer that silently returns nothing is worse than one that refuses, and
+//! `tests/refuses_rather_than_returns_nothing.rs` fails the day it stops.
+//!
+//! # Why one crate and not one per format
+//!
+//! The [`cadmpeg`](https://github.com/cadmpeg/cadmpeg) codecs -- IGES today,
+//! others later -- all decode into a single intermediate representation,
+//! `cadmpeg_ir::CadIr`. The per-format work is therefore only *which decoder to
+//! call*; the part that carries the risk, mapping recovered geometry and
+//! topology onto [`monstertruck_topology`], is shared. So this crate holds one
+//! converter in [`cadmpeg`] and a thin module per format on top of it.
+//!
+//! Each format is a feature, and none is on by default: a consumer that wants
+//! STEP should not compile an IGES reader.
+//!
+//! # Division of labour
+//!
+//! | format | feature | decoder | why |
+//! | --- | --- | --- | --- |
+//! | ISO 10303-21 (STEP) | `step` | [`monstertruck_step`] | monstertruck's own reader and writer |
+//! | IGES 5.3 | `iges` | `cadmpeg-codec-iges` | nothing to gain from writing our own |
+//!
+//! STEP deliberately does **not** go through cadmpeg. monstertruck's own STEP
+//! reader is measured against a corpus, routes analytic surfaces onto closed
+//! forms so booleans stay exact, and reports what a file lost. Measured
+//! 2026-08-04 on `occt-cylinder.step`: monstertruck reads it correctly, and
+//! cadmpeg drops the whole `MANIFOLD_SOLID_BREP` because one parameter-space
+//! `CIRCLE` fails to decode (cadmpeg/cadmpeg#79). Writing STEP stays ours
+//! outright.
+//!
+//! IGES is the opposite case: monstertruck cannot read it at all, and cadmpeg
+//! scores it highly, so "imperfect but loud" beats "absent".
+
+#![cfg_attr(not(debug_assertions), deny(warnings))]
+#![deny(clippy::all, rust_2018_idioms)]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    trivial_casts,
+    trivial_numeric_casts,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications
+)]
+
+mod error;
+
+pub use error::{Error, Result};
+
+#[cfg(feature = "iges")]
+pub mod cadmpeg;
+#[cfg(feature = "iges")]
+pub mod iges;
+#[cfg(feature = "step")]
+pub mod step;

--- a/monstertruck-io/src/step.rs
+++ b/monstertruck-io/src/step.rs
@@ -1,0 +1,9 @@
+//! Reading and writing ISO 10303-21, via [`monstertruck_step`].
+//!
+//! STEP deliberately does not go through cadmpeg. monstertruck's own reader is
+//! measured against a corpus, routes analytic surfaces onto closed forms so the
+//! booleans stay exact, and reports what a file lost; and monstertruck owns the
+//! writer outright. This module exists so a caller can reach every format through
+//! one crate, not to reimplement anything.
+
+pub use monstertruck_step::{load, save};

--- a/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
+++ b/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
@@ -1,0 +1,45 @@
+//! A placeholder importer must REFUSE, not return an empty model.
+//!
+//! The failure this guards against is specific: a caller writes
+//! `let solids = iges::from_path(p)?;`, gets `Ok(vec![])`, and concludes the file
+//! held no geometry. That reading is wrong and silent, and it stays wrong until
+//! someone compares against another tool. So while the conversion is unwritten,
+//! every path returns a typed error, and this row fails the day someone
+//! "helpfully" makes it return an empty vector instead.
+
+#![cfg(feature = "iges")]
+
+use cadmpeg_ir::{CadIr, examples, units::Units};
+use monstertruck_io::{Error, cadmpeg::to_solids};
+
+/// A document with no bodies is a fact about the file, so it gets its own error
+/// rather than the not-implemented one -- otherwise finishing the converter
+/// would silently change what an empty file means.
+#[test]
+fn an_empty_document_reports_no_geometry_not_unimplemented() {
+    let ir = CadIr::empty(Units::default());
+    match to_solids(&ir, "IGES") {
+        Err(Error::NoGeometry { format }) => assert_eq!(format, "IGES"),
+        other => panic!("expected NoGeometry, got {other:?}"),
+    }
+}
+
+/// The unwritten conversion must never look like success.
+#[test]
+fn the_unwritten_conversion_refuses() {
+    // A real IR document with actual topology, from cadmpeg's own examples, so
+    // the row exercises the path a decoded file takes rather than a stub.
+    let ir = examples::unit_cube();
+    assert!(!ir.model.bodies.is_empty(), "the example must carry a body");
+    match to_solids(&ir, "IGES") {
+        Err(Error::Unimplemented { what }) => {
+            assert!(!what.is_empty(), "the error must name what is missing");
+        }
+        Ok(solids) => panic!(
+            "returned Ok with {} solids -- a placeholder that reports success is \
+             indistinguishable from a working importer that found nothing",
+            solids.len()
+        ),
+        other => panic!("expected Unimplemented, got {other:?}"),
+    }
+}

--- a/monstertruck-step/Cargo.toml
+++ b/monstertruck-step/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["graphics"]
 
 [features]
 default = ["load", "derive"]
-load = ["derive", "derive_more", "ruststep", "serde", "monstertruck-traits"]
+load = ["derive", "derive_more", "step-p21", "serde", "monstertruck-traits"]
 derive = ["monstertruck-derive"]
 
 [dependencies]
@@ -23,7 +23,7 @@ derive = ["monstertruck-derive"]
 web-time = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true, optional = true }
-ruststep = { workspace = true, optional = true }
+step-p21 = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 thiserror = { workspace = true }
 monstertruck-assembly = { workspace = true }
@@ -37,7 +37,6 @@ monstertruck-topology = { workspace = true }
 [dev-dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-espr-derive = { workspace = true }
 image = { workspace = true }
 itertools = { workspace = true }
 proptest = { workspace = true }

--- a/monstertruck-step/examples/shape-to-step.rs
+++ b/monstertruck-step/examples/shape-to-step.rs
@@ -40,5 +40,5 @@ fn main() {
     .to_string();
     let mut step_file = std::fs::File::create(output_step_file).unwrap();
     std::io::Write::write_all(&mut step_file, step_string.as_ref()).unwrap();
-    let _ = ruststep::parser::parse(&step_string).unwrap();
+    let _ = step_p21::parser::parse(&step_string).unwrap();
 }

--- a/monstertruck-step/src/lib.rs
+++ b/monstertruck-step/src/lib.rs
@@ -37,14 +37,14 @@
 /// ```
 /// # fn main() -> anyhow::Result<()> {
 /// use monstertruck_step::load::{*, step_geometry::*};
-/// use ruststep::tables::EntityTable;
+/// use step_p21::tables::EntityTable;
 /// // read file
 /// let step_string = include_str!(concat!(
 ///     env!("CARGO_MANIFEST_DIR"),
 ///     "/../resources/step/occt-cube.step",
 /// ));
 /// // parse step file
-/// let exchange = ruststep::parser::parse(&step_string)?;
+/// let exchange = step_p21::parser::parse(&step_string)?;
 /// // convert the parsing results to a Rust struct
 /// let table = Table::from_data_section(&exchange.data[0]);
 /// // get `CartesianPoint` registered in #102

--- a/monstertruck-step/src/load/mod.rs
+++ b/monstertruck-step/src/load/mod.rs
@@ -1,16 +1,16 @@
 #![allow(missing_docs, unused_qualifications)]
 
-/// re-export [`ruststep`](https://docs.rs/ruststep/latest/ruststep/)
-pub use ruststep;
+/// re-export [`step_p21`](https://docs.rs/step_p21/latest/step_p21/)
+pub use step_p21;
 
 use monstertruck_assembly::assy::*;
-use ruststep::{
-    ast::{DataSection, EntityInstance, Name, Parameter, SubSuperRecord},
-    tables::{EntityTable, IntoOwned, PlaceHolder},
-};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::result::Result;
+use step_p21::{
+    ast::{DataSection, EntityInstance, Name, Parameter, SubSuperRecord},
+    tables::{EntityTable, IntoOwned, PlaceHolder},
+};
 
 pub mod convert;
 /// Typed accounting for what a load kept and what it lost.
@@ -27,7 +27,7 @@ use step_geometry::StepConvertingError;
 
 /// Public error type returned by STEP loading entry points.
 ///
-/// Wraps both [`ruststep`] parser failures and the boxed [`StepConvertingError`]
+/// Wraps both [`step_p21`] parser failures and the boxed [`StepConvertingError`]
 /// produced internally by per-entity `TryFrom` impls. `LoadError` is [`Sized`]
 /// and implements [`std::error::Error`] + `Send` + `Sync` + `'static`, so it
 /// composes with `?` from any caller whose result type already accepts a
@@ -36,7 +36,7 @@ use step_geometry::StepConvertingError;
 pub enum LoadError {
     /// The input could not be parsed as a STEP exchange structure.
     #[error("STEP parser error: {0}")]
-    Parse(#[from] ruststep::error::Error),
+    Parse(#[from] step_p21::error::Error),
     /// A per-entity conversion from STEP types into `monstertruck` types failed.
     #[error("STEP conversion error: {0}")]
     Conversion(String),
@@ -178,7 +178,7 @@ impl Table {
     pub fn record_refused_instance(
         &mut self,
         instance: &EntityInstance,
-        error: &ruststep::error::Error,
+        error: &step_p21::error::Error,
     ) {
         let (id, name) = match instance {
             EntityInstance::Simple { id, record } => (*id, record.name.clone()),
@@ -222,7 +222,7 @@ impl Table {
         );
     }
 
-    pub fn push_instance(&mut self, instance: &EntityInstance) -> ruststep::error::Result<()> {
+    pub fn push_instance(&mut self, instance: &EntityInstance) -> step_p21::error::Result<()> {
         match instance {
             EntityInstance::Simple { id, record } => match record.name.as_str() {
                 "CARTESIAN_POINT" => {
@@ -982,7 +982,7 @@ impl Table {
     /// STEP exchange structure.
     #[inline(always)]
     pub fn from_step(step_str: &str) -> Result<Table, LoadError> {
-        let exchange = ruststep::parser::parse(step_str)?;
+        let exchange = step_p21::parser::parse(step_str)?;
         Ok(Table::from_data_section(&exchange.data[0]))
     }
 

--- a/monstertruck-step/src/load/step_types.rs
+++ b/monstertruck-step/src/load/step_types.rs
@@ -1,8 +1,8 @@
 use monstertruck_geometry::prelude as geom;
-use ruststep::{Holder, ast::Name, primitive::Logical, tables::PlaceHolder};
 use serde::{Deserialize, Serialize};
 use std::f64::consts::PI;
 use std::result::Result;
+use step_p21::{Holder, ast::Name, primitive::Logical, tables::PlaceHolder};
 
 use super::Table;
 use super::step_geometry::{self, *};
@@ -959,10 +959,10 @@ impl SurfaceCurveParams {
 
 #[test]
 fn deserialize_pscr() {
-    let (_, p) = ruststep::parser::exchange::parameter(".PCURVE_S1.").unwrap();
+    let (_, p) = step_p21::parser::exchange::parameter(".PCURVE_S1.").unwrap();
     let x = PreferredSurfaceCurveRepresentation::deserialize(&p).unwrap();
     assert!(matches!(x, PreferredSurfaceCurveRepresentation::PcurveS1));
-    let (_, p) = ruststep::parser::exchange::parameter(".PCURVE_S2.").unwrap();
+    let (_, p) = step_p21::parser::exchange::parameter(".PCURVE_S2.").unwrap();
     let x = PreferredSurfaceCurveRepresentation::deserialize(&p).unwrap();
     assert!(matches!(x, PreferredSurfaceCurveRepresentation::PcurveS2));
 }

--- a/monstertruck-step/tests/corpus_conversion_census.rs
+++ b/monstertruck-step/tests/corpus_conversion_census.rs
@@ -30,15 +30,15 @@
 //! ```
 
 use monstertruck_step::load::{SurfaceAny, Table, step_geometry::Surface};
-use ruststep::{
-    ast::{DataSection, EntityInstance, Name, SubSuperRecord},
-    tables::{IntoOwned, PlaceHolder},
-};
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use step_p21::{
+    ast::{DataSection, EntityInstance, Name, SubSuperRecord},
+    tables::{IntoOwned, PlaceHolder},
+};
 
 // ------------------------------------------------------- panic containment
 //
@@ -399,7 +399,7 @@ fn table_with_refusals(bytes: &[u8]) -> Result<(Table, Refusals), String> {
         Ok(text) => text.to_owned(),
         Err(_) => bytes.iter().map(|&b| b as char).collect(),
     };
-    let exchange = ruststep::parser::parse(&text).map_err(|e| e.to_string())?;
+    let exchange = step_p21::parser::parse(&text).map_err(|e| e.to_string())?;
     let section = exchange.data.first().ok_or("no DATA section")?;
     let mut table = Table::default();
     let mut refusals = Refusals::new();

--- a/monstertruck-step/tests/input/geometry.rs
+++ b/monstertruck-step/tests/input/geometry.rs
@@ -6,8 +6,8 @@ use monstertruck_step::{
     save::*,
 };
 use proptest::*;
-use ruststep::{ast::DataSection, tables::*};
 use std::{f64::consts::PI, str::FromStr};
+use step_p21::{ast::DataSection, tables::*};
 
 fn float_to_str(x: f64) -> String {
     if f64::abs(x) < 1.0e-6 {

--- a/monstertruck-step/tests/input/table.rs
+++ b/monstertruck-step/tests/input/table.rs
@@ -1,10 +1,10 @@
 use monstertruck_step::load::*;
-use ruststep::{
+use std::{collections::HashMap, str::FromStr};
+use step_p21::{
     ast::{DataSection, Name},
     primitive::Logical,
     tables::PlaceHolder,
 };
-use std::{collections::HashMap, str::FromStr};
 
 #[test]
 fn read() {

--- a/monstertruck-step/tests/io/oi.rs
+++ b/monstertruck-step/tests/io/oi.rs
@@ -1,14 +1,14 @@
 use monstertruck_geometry::prelude as truck;
 use monstertruck_mesh::PolylineCurve;
 use monstertruck_step::{load::*, save::*};
-use ruststep::{
-    ast::DataSection,
-    tables::{EntityTable, Holder},
-};
 use std::{
     f64::consts::PI,
     fmt::{Debug, Display},
     str::FromStr,
+};
+use step_p21::{
+    ast::DataSection,
+    tables::{EntityTable, Holder},
 };
 use truck::*;
 

--- a/monstertruck-step/tests/output/cylinder.rs
+++ b/monstertruck-step/tests/output/cylinder.rs
@@ -1,9 +1,9 @@
 use monstertruck_geometry::prelude::*;
 use monstertruck_modeling::{Curve as ModelingCurve, Surface as ModelingSurface};
-use monstertruck_step::load::{CylindricalSurfaceHolder, Table, ruststep, step_geometry};
+use monstertruck_step::load::{CylindricalSurfaceHolder, Table, step_geometry, step_p21};
 use monstertruck_step::save::*;
-use ruststep::tables::EntityTable;
 use std::f64::consts::TAU;
+use step_p21::tables::EntityTable;
 
 /// Builds a modeling-layer right circular cylinder as a surface of revolution
 /// of a straight profile line parallel to the revolution axis.

--- a/monstertruck-step/tests/output/geometry.rs
+++ b/monstertruck-step/tests/output/geometry.rs
@@ -7,7 +7,7 @@ where for<'a> StepDisplay<&'a T>: std::fmt::Display {
     assert_eq!(&display.to_string(), ans);
     assert_eq!(x.step_length(), length);
     let step = CompleteStepDisplay::new(display, Default::default()).to_string();
-    ruststep::parser::parse(&step).unwrap();
+    step_p21::parser::parse(&step).unwrap();
 }
 
 #[test]

--- a/monstertruck-step/tests/output/topology.rs
+++ b/monstertruck-step/tests/output/topology.rs
@@ -17,7 +17,7 @@ fn parse_solid() {
         let solid: CompressedSolid = serde_json::from_reader(json.as_slice()).unwrap();
         let step_string =
             CompleteStepDisplay::new(StepModel::from(&solid), Default::default()).to_string();
-        ruststep::parser::parse(&step_string).unwrap_or_else(|e| {
+        step_p21::parser::parse(&step_string).unwrap_or_else(|e| {
             panic!(
                 "failed to parse step from {json_file}\n[Error Message]\n{e}[STEP file]\n{step_string}"
             )
@@ -33,7 +33,7 @@ fn parse_shell() {
         let shell = solid.boundaries.pop().unwrap();
         let step_string =
             CompleteStepDisplay::new(StepModel::from(&shell), Default::default()).to_string();
-        ruststep::parser::parse(&step_string).unwrap_or_else(|e| {
+        step_p21::parser::parse(&step_string).unwrap_or_else(|e| {
             panic!(
                 "failed to parse step from {json_file}\n[Error Message]\n{e}[STEP file]\n{step_string}"
             )
@@ -52,7 +52,7 @@ fn parse_solids() {
         .collect();
     let step_string =
         CompleteStepDisplay::new(StepModels::from_iter(&solids), Default::default()).to_string();
-    ruststep::parser::parse(&step_string).unwrap_or_else(|e| {
+    step_p21::parser::parse(&step_string).unwrap_or_else(|e| {
         panic!("failed to parse step\n[Error Message]\n{e}[STEP file]\n{step_string}")
     });
 }

--- a/monstertruck-step/tests/output/watertight.rs
+++ b/monstertruck-step/tests/output/watertight.rs
@@ -77,7 +77,7 @@ fn edge_uses(step: &str) -> (BTreeSet<u64>, BTreeMap<u64, usize>) {
 /// syntactically valid, every `EDGE_CURVE` is referenced by exactly two
 /// `ORIENTED_EDGE`s, and no `ORIENTED_EDGE` references an undefined edge.
 fn assert_closed_manifold(label: &str, step: &str) -> anyhow::Result<()> {
-    ruststep::parser::parse(step)
+    step_p21::parser::parse(step)
         .map_err(|error| anyhow::anyhow!("{label}: emitted STEP did not parse: {error}"))?;
 
     let (defined, references) = edge_uses(step);

--- a/monstertruck-step/tests/swept_surface_extent_oracle.rs
+++ b/monstertruck-step/tests/swept_surface_extent_oracle.rs
@@ -73,14 +73,14 @@ use monstertruck_step::load::{
         },
     },
 };
-use ruststep::{
-    ast::Name,
-    tables::{EntityTable, IntoOwned, PlaceHolder},
-};
 use std::cell::{Cell, RefCell};
 use std::collections::{BTreeMap, HashMap};
 use std::panic::AssertUnwindSafe;
 use std::path::{Path, PathBuf};
+use step_p21::{
+    ast::Name,
+    tables::{EntityTable, IntoOwned, PlaceHolder},
+};
 
 // ------------------------------------------------------- panic containment
 //

--- a/monstertruck-step/tests/tokenize_bisect.rs
+++ b/monstertruck-step/tests/tokenize_bisect.rs
@@ -89,12 +89,12 @@ fn bisect_ai14r() { bisect("Ai-14R", "Ai-14R.stp") }
 /// ISO 10303-21 escapes a literal `'` inside a string by doubling it. Imperial
 /// CAD is full of them -- inch marks in thread callouts and part names.
 ///
-/// Published ruststep 0.4.0 refuses the escape. UN-IGNORED: this test IS the
+/// Published step_p21 0.4.0 refuses the escape. UN-IGNORED: this test IS the
 /// acceptance test for the upstream fix, which landed in
-/// <https://github.com/ricosjp/ruststep/pull/254> (originally
-/// <https://github.com/ricosjp/ruststep/pull/251>) and reaches us through the
+/// <https://github.com/ricosjp/step_p21/pull/254> (originally
+/// <https://github.com/ricosjp/step_p21/pull/251>) and reaches us through the
 /// `[patch.crates-io]` rev pin in the workspace manifest. It goes red again if
-/// that pin is dropped before ruststep publishes a release containing the fix.
+/// that pin is dropped before step_p21 publishes a release containing the fix.
 #[test]
 fn escaped_apostrophe_in_a_string_literal() {
     let base = |name: &str| {
@@ -148,10 +148,10 @@ fn minimal(entity: &str) -> String {
 /// not the window, the entity type, or the harness. In particular the non-empty
 /// aggregate differs by exactly one element.
 ///
-/// Published ruststep 0.4.0 refuses `()`. UN-IGNORED: this test IS the
+/// Published step_p21 0.4.0 refuses `()`. UN-IGNORED: this test IS the
 /// acceptance test for the upstream fix, which landed in
-/// <https://github.com/ricosjp/ruststep/pull/254> (originally
-/// <https://github.com/ricosjp/ruststep/pull/251>) and reaches us through the
+/// <https://github.com/ricosjp/step_p21/pull/254> (originally
+/// <https://github.com/ricosjp/step_p21/pull/251>) and reaches us through the
 /// `[patch.crates-io]` rev pin in the workspace manifest.
 #[test]
 fn empty_aggregate_in_an_entity_parameter() {


### PR DESCRIPTION
Rebased on master after #9, so this branch uses `cargo-rdme`. Two commits.

## 1. STEP now reads through `step-p21` 0.1.0

The `[patch.crates-io]` pin fixed our build and nothing else. Published
`monstertruck-step 0.3.2` declares `ruststep ^0.4`, so **every consumer got a
tokenizer that rejects two constructs real CAD exports contain**:

- `''` -- an escaped apostrophe, which imperial CAD emits constantly as inch
  marks in thread callouts;
- `()` -- an empty aggregate, e.g. `ADVANCED_FACE('',(),#57075,.T.)`.

Both fixes sat unreleased on `ruststep` master for four years. A patch section
cannot ship them to dependents, only to us. `step-p21` is our fork of
`ricosjp/ruststep` at `cd89e5a`, published, carrying both -- so the next
`monstertruck-step` release is the first one whose users actually get them.

The patch section and the unused `espr-derive` requirement come off with it. The
import reordering in the same commit is `rustfmt` fallout: `step_p21` sorts after
`serde`/`std` where `ruststep` sorted before them.

**Verified:** `cargo test -p monstertruck-step` -- 34+39+20+8+7+3+2+2+1 pass, 0 fail.

## 2. New crate: `monstertruck-io`

An **aggregator, not a replacement**. `monstertruck-step` stays the STEP
implementation and stays published; `io::step` re-exports it. What is new is
IGES, which monstertruck cannot read at all and which cadmpeg decodes well.

The cadmpeg codecs all decode into *one* intermediate representation, so the
per-format work is only which decoder to call, and the risky part -- mapping
recovered geometry onto our B-rep -- is shared. Hence one converter module, a
thin module per format, and one feature per format with **none on by default**:
a consumer who wants STEP should not compile an IGES reader.

STEP deliberately does not route through cadmpeg. Measured 2026-08-04 on
`occt-cylinder.step`: monstertruck reads it, cadmpeg drops the whole
`MANIFOLD_SOLID_BREP` over one parameter-space `CIRCLE`
(cadmpeg/cadmpeg#79).

### The IGES conversion is unwritten, and says so

It returns a typed `Unimplemented`, never an empty model, and an empty document
gets its own `NoGeometry` variant -- so a caller cannot read "not written yet" as
"this file held no geometry". `publish = false` for the same reason: a crate whose
only novel entry point refuses is not an importer yet.

`tests/refuses_rather_than_returns_nothing.rs` fails the day someone helpfully
returns `Ok(vec![])`. It drives the real path with cadmpeg's own
`examples::unit_cube` rather than a stub.

Its README is generated by `cargo-rdme` and the crate is registered in
`rdme_crates`, so `just readme-check` covers it -- a hand-written README beside
doc comments only drifts.

**Verified locally:** `just fmt-check`, `just lint-check` and `just readme-check`
all exit 0; 2 `monstertruck-io` tests pass; docs and `clippy -D warnings` clean
under `iges`, `step` and no features; workspace `cargo check --all-targets` clean.