### PR TITLE
Restore the ruststep attribution, and alias the renamed re-export

### DIFF
--- a/monstertruck-step/src/load/mod.rs
+++ b/monstertruck-step/src/load/mod.rs
@@ -1,7 +1,15 @@
 #![allow(missing_docs, unused_qualifications)]
 
-/// re-export [`step_p21`](https://docs.rs/step_p21/latest/step_p21/)
+/// re-export [`step_p21`](https://docs.rs/step-p21/latest/step_p21/)
 pub use step_p21;
+
+/// The former name of the [`step_p21`] re-export, when the parser was upstream
+/// `ruststep`. Kept so `load::ruststep::...` paths keep compiling.
+#[deprecated(
+    since = "0.3.4",
+    note = "the parser is now `step-p21`; use `monstertruck_step::load::step_p21` instead"
+)]
+pub use step_p21 as ruststep;
 
 use monstertruck_assembly::assy::*;
 use serde::Deserialize;

--- a/monstertruck-step/tests/ruststep_alias_still_resolves.rs
+++ b/monstertruck-step/tests/ruststep_alias_still_resolves.rs
@@ -1,0 +1,27 @@
+//! The `ruststep` re-export path must keep resolving after the rename.
+//!
+//! `monstertruck_step::load::ruststep` was the parser re-export for as long as
+//! the parser was upstream `ruststep`. Renaming it to `step_p21` without an alias
+//! silently breaks every `load::ruststep::...` path a consumer wrote, and a
+//! consumer has no way to see that coming from a version bump. The alias is
+//! deprecated, not removed, so the break is a warning rather than a compile
+//! error.
+//!
+//! This is a type-identity check: it passes only if both paths name the SAME
+//! type, so an alias pointing at something else would not compile.
+
+#![cfg(feature = "load")]
+#![allow(deprecated)]
+
+use monstertruck_step::load::{ruststep, step_p21};
+
+/// Compiles only if `ruststep::ast::Name` and `step_p21::ast::Name` are one type.
+fn _the_two_paths_name_one_type(name: ruststep::ast::Name) -> step_p21::ast::Name { name }
+
+#[test]
+fn the_deprecated_ruststep_path_still_resolves() {
+    // Reached through the OLD path, compared against a value built the new way.
+    let old: ruststep::ast::Name = ruststep::ast::Name::Entity(7);
+    let new: step_p21::ast::Name = step_p21::ast::Name::Entity(7);
+    assert_eq!(old, new, "the alias must reach the same parser, not a copy");
+}

--- a/monstertruck-step/tests/tokenize_bisect.rs
+++ b/monstertruck-step/tests/tokenize_bisect.rs
@@ -89,12 +89,12 @@ fn bisect_ai14r() { bisect("Ai-14R", "Ai-14R.stp") }
 /// ISO 10303-21 escapes a literal `'` inside a string by doubling it. Imperial
 /// CAD is full of them -- inch marks in thread callouts and part names.
 ///
-/// Published step_p21 0.4.0 refuses the escape. UN-IGNORED: this test IS the
-/// acceptance test for the upstream fix, which landed in
-/// <https://github.com/ricosjp/step_p21/pull/254> (originally
-/// <https://github.com/ricosjp/step_p21/pull/251>) and reaches us through the
-/// `[patch.crates-io]` rev pin in the workspace manifest. It goes red again if
-/// that pin is dropped before step_p21 publishes a release containing the fix.
+/// Published `ruststep` 0.4.0 refuses the escape. UN-IGNORED: this test IS the
+/// acceptance test for the fix, which landed on ruststep master in
+/// <https://github.com/ricosjp/ruststep/pull/254> (originally
+/// <https://github.com/ricosjp/ruststep/pull/251>) but was never released, so
+/// it reaches us through `step-p21` -- our published fork carrying both. It goes red again if the
+/// dependency is moved back to a `ruststep` release.
 #[test]
 fn escaped_apostrophe_in_a_string_literal() {
     let base = |name: &str| {
@@ -148,11 +148,11 @@ fn minimal(entity: &str) -> String {
 /// not the window, the entity type, or the harness. In particular the non-empty
 /// aggregate differs by exactly one element.
 ///
-/// Published step_p21 0.4.0 refuses `()`. UN-IGNORED: this test IS the
-/// acceptance test for the upstream fix, which landed in
-/// <https://github.com/ricosjp/step_p21/pull/254> (originally
-/// <https://github.com/ricosjp/step_p21/pull/251>) and reaches us through the
-/// `[patch.crates-io]` rev pin in the workspace manifest.
+/// Published `ruststep` 0.4.0 refuses `()`. UN-IGNORED: this test IS the
+/// acceptance test for the fix, which landed on ruststep master in
+/// <https://github.com/ricosjp/ruststep/pull/254> (originally
+/// <https://github.com/ricosjp/ruststep/pull/251>) but was never released, so
+/// it reaches us through `step-p21` -- our published fork carrying both.
 #[test]
 fn empty_aggregate_in_an_entity_parameter() {
     let cases = [


### PR DESCRIPTION
Two defects from #10, both from renaming `ruststep` to `step_p21` too broadly.

## 1. Broken attribution, and inverted prose

The blanket rename rewrote four upstream URLs to `github.com/ricosjp/step_p21`,
which does not exist -- ricosjp's repo is `ruststep`, and Apache-2.0 attribution
has to point at it.

The surrounding prose was inverted in the process. It read:

> Published step_p21 0.4.0 refuses the escape.

`step-p21` is precisely the fork that **accepts** it, and there is no 0.4.0 of it.
The crate that refuses is published `ruststep` 0.4.0. The same block still claimed
the fix "reaches us through the `[patch.crates-io]` rev pin in the workspace
manifest" -- which #10 deleted.

## 2. `load::ruststep` was renamed with no alias

`monstertruck_step::load::ruststep` was the parser re-export for as long as the
parser was upstream `ruststep`. #10 renamed it to `step_p21` outright, so every
`load::ruststep::...` path a consumer wrote stops compiling on a patch bump, with
no warning and nothing naming the replacement. That is against this repo's own
rule that a rename ships a `#[deprecated]` alias.

Restored as a deprecated re-export.

### Pinned by type identity, not by name

`tests/ruststep_alias_still_resolves.rs` hands a value through the **old** path
into a signature written in the **new** one:

```rust
fn _the_two_paths_name_one_type(name: ruststep::ast::Name) -> step_p21::ast::Name {
    name
}
```

So an alias pointing at a different or vendored parser fails to compile rather
than passing. A name-only assertion would not catch that.

**Verified:** `cargo test -p monstertruck-step` -- 34+39+20+8+8+3+2+2+1+1 pass, 0
fail; `cargo fmt --all --check` clean.