### PR TITLE
Sweep every STEP fixture, so a moved one fails at the fixture and not eight rows away

### DIFF
--- a/monstertruck-io/tests/every_fixture_loads.rs
+++ b/monstertruck-io/tests/every_fixture_loads.rs
@@ -1,0 +1,144 @@
+//! Every STEP fixture in the repository must load. No exceptions, no list to
+//! forget to update.
+//!
+//! This exists because of a real failure. Folding `monstertruck-step` into this
+//! crate moved `tests/fixtures/real-world/`, and seven hardcoded
+//! `../monstertruck-step/tests/fixtures/real-world` paths elsewhere in the
+//! workspace were left behind. Nothing here noticed: every fixture test names
+//! its files as string literals, so a fixture that has MOVED is
+//! indistinguishable from one that was never mentioned. The breakage surfaced
+//! far away, as eight unrelated-looking boolean rows dying at `read`, and cost
+//! another agent a debugging session to trace back.
+//!
+//! Two properties make this row catch that class of defect:
+//!
+//! 1. **The corpora are ENUMERATED, not listed.** A fixture added to either
+//!    directory is covered the moment it lands, with nothing to update here.
+//! 2. **An empty or missing directory FAILS.** This is the whole point. A glob
+//!    over a directory that moved yields zero files, and a test that merely
+//!    iterates would report success over nothing -- the precise shape of the
+//!    original defect. Each corpus therefore asserts a floor on how many files
+//!    it must contain.
+//!
+//! Every failure is collected and reported together: when a loader change
+//! breaks input handling, seeing every affected file at once is worth far more
+//! than seeing whichever one sorted first.
+
+#![cfg(feature = "load")]
+
+use monstertruck_io::step::load::Table;
+use std::path::{Path, PathBuf};
+
+/// A directory of fixtures, and the minimum number of files it must hold.
+///
+/// The floor is a MOVED-DIRECTORY GUARD, not an inventory count. It is set below
+/// the current population on purpose, so adding a fixture never fails this row
+/// while removing the directory always does.
+struct Corpus {
+    /// Path relative to this crate's manifest directory.
+    relative_path: &'static str,
+    /// Fewer files than this means the directory moved, emptied, or was gated
+    /// out -- all of which must be loud.
+    minimum_files: usize,
+}
+
+const CORPORA: [Corpus; 1] = [
+    // The shared `resources` submodule: small analytic solids plus ABC samples.
+    // The frozen third-party exports live only in the private tree, so this
+    // repository has one corpus where that one has two.
+    Corpus {
+        relative_path: "../resources/step",
+        minimum_files: 10,
+    },
+];
+
+fn corpus_dir(corpus: &Corpus) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(corpus.relative_path)
+}
+
+/// Every `.step`/`.stp` file in `dir`, sorted so failure output is stable.
+fn step_files(dir: &Path) -> Vec<PathBuf> {
+    let entries = std::fs::read_dir(dir)
+        .unwrap_or_else(|err| panic!("fixture directory {} is unreadable: {err}", dir.display()));
+    let mut files: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|e| e.path()))
+        .filter(|path| {
+            path.extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| {
+                    ext.eq_ignore_ascii_case("step") || ext.eq_ignore_ascii_case("stp")
+                })
+        })
+        .collect();
+    files.sort();
+    files
+}
+
+#[test]
+fn every_fixture_in_the_repository_loads() {
+    let mut failures: Vec<String> = Vec::new();
+    let mut loaded = 0usize;
+
+    for corpus in &CORPORA {
+        let dir = corpus_dir(corpus);
+        assert!(
+            dir.is_dir(),
+            "fixture directory {} does not exist -- it moved, or a rename left this path behind",
+            dir.display(),
+        );
+
+        let files = step_files(&dir);
+        assert!(
+            files.len() >= corpus.minimum_files,
+            "{} holds {} STEP files, expected at least {}. A directory that moved \
+             or emptied yields nothing to iterate, and a sweep over nothing passes \
+             silently -- which is the defect this row exists to catch.",
+            dir.display(),
+            files.len(),
+            corpus.minimum_files,
+        );
+
+        for path in files {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned();
+            let bytes = match std::fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(err) => {
+                    failures.push(format!("{name}: unreadable: {err}"));
+                    continue;
+                }
+            };
+            match Table::from_step_bytes(&bytes) {
+                Ok(table) => {
+                    // Parsing "succeeded" is not enough: a file that yields no
+                    // geometry at all has not been read in any useful sense, and
+                    // every fixture here carries points.
+                    if table.cartesian_point.is_empty() {
+                        failures.push(format!(
+                            "{name}: parsed, but produced ZERO cartesian points -- \
+                             read as empty rather than read"
+                        ));
+                    } else {
+                        loaded += 1;
+                    }
+                }
+                Err(err) => failures.push(format!("{name}: {err}")),
+            }
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} fixtures failed to load:\n  {}",
+        failures.len(),
+        failures.len() + loaded,
+        failures.join("\n  "),
+    );
+    assert!(
+        loaded >= 10,
+        "expected at least 10 fixtures (10 present when this was written), loaded {loaded}"
+    );
+}

--- a/monstertruck-modeling/src/geometry.rs
+++ b/monstertruck-modeling/src/geometry.rs
@@ -188,7 +188,7 @@ fn linear_bspline_division(
 /// question there is never whether THIS representative is inside the range but
 /// whether ANY whole-period offset of it is -- mirroring the period branch of
 /// the STEP loader's `normalize_axis`
-/// (`monstertruck-step/src/load/step_geometry/geom_impls.rs`), except that this
+/// (`monstertruck-io/src/step/load/step_geometry/geom_impls.rs`), except that this
 /// one only MEASURES; it never rewrites the value.
 ///
 /// A non-finite value is infinitely far outside every bounded domain.
@@ -236,7 +236,7 @@ struct SurfaceParameterDomain {
 /// regard it as a segment"), and `Line::evaluate` is `p0 + t * (p1 - p0)`, so
 /// the parameter is a multiple of the CHORD, not a fraction of any real extent.
 /// The STEP loader builds a cylinder's profile as `Line(p, p + z)` with a UNIT
-/// axis direction (`monstertruck-step/src/load/step_types.rs`,
+/// axis direction (`monstertruck-io/src/step/load/step_types.rs`,
 /// `From<&CylindricalSurface>`), so `t` there is a world-scale axial distance
 /// on an axially UNBOUNDED surface and `[0, 1]` is one arbitrary metre of it.
 ///
@@ -520,7 +520,7 @@ const fn attempt_plan(attempt: usize) -> (bool, bool) {
 /// The four solver attempts follow [`attempt_plan`]: the two HINTED attempts
 /// first, then the two unhinted ones, alternating solvers within each pair, with
 /// [`EXACT_FIRST`] choosing only which solver opens. This is NOT the plan of the
-/// STEP loader's twin (`monstertruck-step/src/load/step_geometry/geom_impls.rs`,
+/// STEP loader's twin (`monstertruck-io/src/step/load/step_geometry/geom_impls.rs`,
 /// `sampled_parameter_boundary`), which groups by solver instead; see
 /// [`attempt_plan`] for the full asymmetry. Both solvers are unbounded Newtons
 /// (`monstertruck-traits/src/algo/surface.rs`), so either can walk off the end
@@ -559,7 +559,7 @@ const fn attempt_plan(attempt: usize) -> (bool, bool) {
 /// lands. Both routes hand a `NaN` or `inf` parameter to downstream geometry.
 ///
 /// The STEP loader's twin has never had either route: its `normalize_axis`
-/// (`monstertruck-step/src/load/step_geometry/geom_impls.rs`) returns `None` for
+/// (`monstertruck-io/src/step/load/step_geometry/geom_impls.rs`) returns `None` for
 /// a non-finite value, so the whole chain fails typed. Rejecting rather than
 /// clamping is C3's resolution style, and rejecting rather than substituting a
 /// value keeps this routine's promise that every answer it returns came from a
@@ -1672,7 +1672,7 @@ pub enum Surface {
     /// Carried as the analytic type rather than its (exact) rational net so the
     /// CLOSED-FORM [`ParameterDivision2D`] survives the STEP conversion -- see
     /// the module note on `TryFrom<&Surface> for Surface` in
-    /// `monstertruck-step/src/load/step_geometry/geom_impls.rs`. Spec 012 U1.2.
+    /// `monstertruck-io/src/step/load/step_geometry/geom_impls.rs`. Spec 012 U1.2.
     SphericalSurface(Processor<Sphere, Matrix4>),
     /// Analytic torus, posed by the processor's transform. Same reason as
     /// [`Surface::SphericalSurface`]; spindle tori never reach this variant.
@@ -2885,7 +2885,7 @@ mod project_domain_tests {
     /// axis is real, and the two must be decided independently.
     ///
     /// Built the way `From<&CylindricalSurface>`
-    /// (`monstertruck-step/src/load/step_types.rs`) builds one: revolve
+    /// (`monstertruck-io/src/step/load/step_types.rs`) builds one: revolve
     /// `Line(p, p + z)` with a UNIT axis, then invert -- which swaps the
     /// `Processor`'s axes, so the periodic axis is `u`. A face on such a
     /// cylinder legitimately occupies tens of world units of `v`, and the


### PR DESCRIPTION
## What broke

The `monstertruck-io` fold moved the fixture directories. The rewrite that came
with it repointed **Rust** paths (`monstertruck_step::` -> `monstertruck_io::step::`)
and never touched **filesystem path strings** -- a whole class of reference it
could not see.

In the private tree that stranded seven `../monstertruck-step/tests/fixtures/real-world`
paths and took out eight boolean rows at `read`, eight rows away from anything
that looked like a cause.

## Why nothing caught it

Every fixture test names its files as string literals. So a fixture that has
**moved** is indistinguishable from one that was **never mentioned** -- the suite
cannot tell the difference, and reports green either way.

## The fix

`tests/every_fixture_loads.rs`:

- **Enumerates** `resources/step` rather than listing it, so a fixture added
  there is covered the moment it lands, with nothing to update.
- **Fails on an empty or missing directory.** This is the point: a sweep over a
  directory that moved finds nothing to iterate, and would otherwise report
  success over nothing -- exactly the shape of the original defect. Hence the
  floor on file count.
- **Collects every failure** and reports them together, since a loader
  regression wants the whole list, not whichever file sorted first.
- Requires each file to yield geometry, not merely parse: zero `CARTESIAN_POINT`s
  is "read as empty", not "read".

## Verified by negative control

A green sweep proves nothing until it has been seen to go red for the right
reason. Moving `resources/step` away yields:

```
fixture directory .../monstertruck-io/../resources/step does not exist
  -- it moved, or a rename left this path behind
```

All 10 fixtures load today. `cargo fmt --check`, workspace clippy, and
`just readme-check` are all clean.

Also repoints 6 doc comments that still cited `monstertruck-step/src/...` as the
home of code the fold moved.

This repository has **one** corpus where the private tree has two -- the frozen
third-party exports are private-only.