### PR TITLE
Put cadmpeg's STEP reader alongside ours, behind a `cadmpeg` feature

### DIFF
--- a/monstertruck-io/Cargo.toml
+++ b/monstertruck-io/Cargo.toml
@@ -31,8 +31,15 @@ load = [
     "monstertruck-traits",
 ]
 derive = ["monstertruck-derive"]
-# Reading IGES 5.3, via the cadmpeg codec.
-iges = ["cadmpeg-codec-iges", "cadmpeg-codec-core", "cadmpeg-ir"]
+# The cadmpeg intermediate representation, its converter, and the cadmpeg-backed
+# readers. STEP is deliberately available through BOTH this and the `step`
+# feature above: ours is the measurement baseline the boolean kernel is
+# characterised against, and swapping it out is not a decision to make without
+# evidence. Enabling both lets the two be run over the same corpus and diffed.
+cadmpeg = ["cadmpeg-ir", "cadmpeg-core", "cadmpeg-codec-step"]
+# Reading IGES 5.3. monstertruck has no IGES reader of its own, so this one has
+# no alternative to sit alongside.
+iges = ["cadmpeg", "cadmpeg-codec-iges"]
 
 [dependencies]
 monstertruck-core = { workspace = true }
@@ -55,10 +62,12 @@ monstertruck-mesh = { workspace = true }
 
 # IGES. The cadmpeg codecs all decode into ONE intermediate representation, which
 # is why this crate holds a single converter rather than one per format.
-cadmpeg-ir = { version = "0.3", optional = true }
-cadmpeg-codec-iges = { version = "0.3", optional = true }
-# `ReadSeek` is public here rather than in cadmpeg-ir.
-cadmpeg-codec-core = { version = "0.3", optional = true }
+cadmpeg-ir = { version = "0.4", optional = true }
+cadmpeg-codec-iges = { version = "0.4", optional = true }
+cadmpeg-codec-step = { version = "0.4", optional = true }
+# `ReadSeek` lives here, not in cadmpeg-ir. Renamed from `cadmpeg-codec-core`
+# at 0.4; depending on both would give two incompatible `ReadSeek` traits.
+cadmpeg-core = { version = "0.4", optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/monstertruck-io/src/cadmpeg/mod.rs
+++ b/monstertruck-io/src/cadmpeg/mod.rs
@@ -26,6 +26,8 @@
 //! [`CompressedShell`]: monstertruck_topology::compress::CompressedShell
 //! [`Surface::Plane`]: monstertruck_modeling::Surface
 
+pub mod step;
+
 use crate::{Error, Result};
 use monstertruck_modeling::{Curve, Point3, Surface};
 use monstertruck_topology::compress::CompressedSolid;

--- a/monstertruck-io/src/cadmpeg/step.rs
+++ b/monstertruck-io/src/cadmpeg/step.rs
@@ -1,0 +1,81 @@
+//! Reading ISO 10303-21 through `cadmpeg-codec-step`, alongside our own reader.
+//!
+//! This is a **second** STEP reader, deliberately. [`crate::step`] is
+//! monstertruck's own, built on `step-p21`, and it stays the default: it is the
+//! measurement baseline the boolean kernel is characterised against -- the
+//! frozen digests, the corpus conversion census and the failure classes all
+//! describe the B-rep *it* produces. Replacing it is not a dependency swap, it
+//! invalidates that evidence.
+//!
+//! So rather than choose blind, both are compiled in when the `cadmpeg` feature
+//! is on, and can be run over the same corpus and compared. The swap becomes a
+//! decision with a measurement behind it, or it does not happen.
+//!
+//! # What cadmpeg brings
+//!
+//! Measured 2026-08-06 against cadmpeg 0.4 over the ten in-repo STEP fixtures:
+//! every one decodes, with exact analytic carriers (plane, cylinder, cone,
+//! sphere, torus, NURBS) rather than tessellation, and topology that checks out
+//! -- `occt-cube` gives 6 faces, 12 edges and 8 vertices, Euler 8 - 12 + 6 = 2.
+//! `occt-assy` yields two bodies, so assemblies survive.
+//!
+//! That is a change from 2026-08-04, when `occt-cylinder.step` dropped its whole
+//! `MANIFOLD_SOLID_BREP` because one parameter-space `CIRCLE` failed to decode.
+//! That was cadmpeg/cadmpeg#79, and cadmpeg/cadmpeg#83 fixed it.
+//!
+//! # What is not yet decided
+//!
+//! Their STEP codec also *writes* (their support ladder calls it L9, which
+//! includes source-less generation). That is untested here: "writes back a
+//! document it decoded" is a weaker claim than "generates correct STEP from an
+//! arbitrary foreign B-rep", which is what replacing our writer would need.
+//! Until that is measured, writing STEP stays ours outright.
+
+use crate::{
+    Error, Result,
+    cadmpeg::{ImportedSolid, to_solids},
+};
+use cadmpeg_core::ReadSeek;
+use cadmpeg_ir::CadIr;
+use cadmpeg_ir::codec::{CodecEntry, DecodeOptions};
+
+const FORMAT: &str = "STEP (cadmpeg)";
+
+/// Decode a STEP stream to cadmpeg's intermediate representation.
+///
+/// Stops one step short of monstertruck's B-rep on purpose. The comparison this
+/// module exists for is against the *recovered geometry and topology*, and that
+/// is what the intermediate representation carries; going all the way to a
+/// [`ImportedSolid`] would fold our conversion's own defects into the reading
+/// being measured.
+pub fn decode_to_ir(reader: &mut dyn ReadSeek) -> Result<CadIr> {
+    let decoded = cadmpeg_codec_step::StepCodec::default()
+        .decode(reader, &DecodeOptions::default())
+        .map_err(|error| Error::Decode {
+            format: FORMAT,
+            message: error.to_string(),
+        })?;
+    Ok(decoded.ir)
+}
+
+/// Decode a STEP file to cadmpeg's intermediate representation.
+pub fn decode_file_to_ir(path: impl AsRef<std::path::Path>) -> Result<CadIr> {
+    let mut file = std::fs::File::open(path)?;
+    decode_to_ir(&mut file)
+}
+
+/// Read solids from a STEP stream, through cadmpeg rather than [`crate::step`].
+///
+/// Shares [`to_solids`] with every other format, so it carries that converter's
+/// current state: while the conversion is unwritten this returns
+/// [`Error::Unimplemented`] rather than an empty model.
+pub fn from_reader(reader: &mut dyn ReadSeek) -> Result<Vec<ImportedSolid>> {
+    let ir = decode_to_ir(reader)?;
+    to_solids(&ir, FORMAT)
+}
+
+/// Read solids from a STEP file, through cadmpeg rather than [`crate::step`].
+pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Vec<ImportedSolid>> {
+    let mut file = std::fs::File::open(path)?;
+    from_reader(&mut file)
+}

--- a/monstertruck-io/src/iges.rs
+++ b/monstertruck-io/src/iges.rs
@@ -9,7 +9,7 @@ use crate::{
     Result,
     cadmpeg::{ImportedSolid, to_solids},
 };
-use cadmpeg_codec_core::ReadSeek;
+use cadmpeg_core::ReadSeek;
 use cadmpeg_ir::codec::{CodecEntry, DecodeOptions};
 
 const FORMAT: &str = "IGES";

--- a/monstertruck-io/src/lib.rs
+++ b/monstertruck-io/src/lib.rs
@@ -67,13 +67,14 @@
 
 // `monstertruck-derive` emits `monstertruck_io::step::save::...` into the code
 // it generates, and a crate cannot name itself in a path without this alias.
+#[cfg(feature = "load")]
 extern crate self as monstertruck_io;
 
 mod error;
 
 pub use error::{Error, Result};
 
-#[cfg(feature = "iges")]
+#[cfg(feature = "cadmpeg")]
 pub mod cadmpeg;
 #[cfg(feature = "iges")]
 pub mod iges;

--- a/monstertruck-io/tests/cadmpeg_reads_the_step_corpus.rs
+++ b/monstertruck-io/tests/cadmpeg_reads_the_step_corpus.rs
@@ -1,0 +1,108 @@
+//! The cadmpeg-backed STEP reader must read the same corpus ours does.
+//!
+//! `monstertruck-io` carries two STEP readers on purpose: our own on `step-p21`
+//! (the default, and the measurement baseline the boolean kernel is
+//! characterised against) and cadmpeg's behind the `cadmpeg` feature. Keeping
+//! the second one compiled but unexercised would tell us nothing about whether
+//! it could ever replace the first, which is the only reason it is here.
+//!
+//! So this row reads every in-repo STEP fixture through cadmpeg and asserts the
+//! recovered *topology*, not merely that decoding returned `Ok`. A decoder that
+//! parses a file and recovers no faces has not read it in any sense that matters
+//! to a B-rep kernel -- and that was the real failure mode: on 2026-08-04
+//! `occt-cylinder.step` decoded "successfully" while dropping its entire
+//! `MANIFOLD_SOLID_BREP`, because one parameter-space `CIRCLE` failed
+//! (cadmpeg/cadmpeg#79, fixed in cadmpeg/cadmpeg#83).
+//!
+//! The expected counts below are MEASURED against cadmpeg 0.4, not guessed, and
+//! they are exact: STEP decoding is deterministic, so a change in either the
+//! fixture or the decoder trips this row rather than passing quietly.
+
+#![cfg(feature = "cadmpeg")]
+
+use monstertruck_io::cadmpeg::step::decode_file_to_ir;
+use std::path::{Path, PathBuf};
+
+/// `(fixture, bodies, faces, edges, vertices)`, measured against cadmpeg 0.4.
+///
+/// `occt-cube` is the one to sanity-check by hand: 6 faces, 12 edges, 8 vertices
+/// gives Euler 8 - 12 + 6 = 2, a closed genus-0 solid. A sphere and a torus are
+/// single seam-degenerate faces, hence zero edges.
+const EXPECTED: [(&str, usize, usize, usize, usize); 10] = [
+    ("abc-0000.step", 6, 25, 33, 32),
+    ("abc-0006.step", 1, 15, 32, 20),
+    ("abc-0008.step", 1, 21, 34, 26),
+    ("abc-0035.step", 1, 82, 188, 122),
+    ("occt-assy.step", 2, 9, 15, 10),
+    ("occt-cone.step", 1, 3, 3, 2),
+    ("occt-cube.step", 1, 6, 12, 8),
+    ("occt-cylinder.step", 1, 3, 3, 2),
+    ("occt-sphere.step", 1, 1, 0, 1),
+    ("occt-torus.step", 1, 1, 0, 1),
+];
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../resources/step")
+        .join(name)
+}
+
+#[test]
+fn cadmpeg_recovers_the_expected_topology_from_every_fixture() {
+    let mut failures = Vec::new();
+
+    for (name, bodies, faces, edges, vertices) in EXPECTED {
+        let path = fixture(name);
+        assert!(
+            path.is_file(),
+            "fixture {} is missing -- it moved, or a rename left this path behind",
+            path.display(),
+        );
+
+        let ir = match decode_file_to_ir(&path) {
+            Ok(ir) => ir,
+            Err(error) => {
+                failures.push(format!("{name}: decode failed: {error}"));
+                continue;
+            }
+        };
+
+        let got = (
+            ir.model.bodies.len(),
+            ir.model.faces.len(),
+            ir.model.edges.len(),
+            ir.model.vertices.len(),
+        );
+        if got != (bodies, faces, edges, vertices) {
+            failures.push(format!(
+                "{name}: bodies/faces/edges/vertices = {got:?}, expected \
+                 {:?}",
+                (bodies, faces, edges, vertices)
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "{} of {} fixtures did not match:\n  {}",
+        failures.len(),
+        EXPECTED.len(),
+        failures.join("\n  "),
+    );
+}
+
+/// The fixture that regressed, pinned on its own so a failure names the defect.
+#[test]
+fn the_cylinder_that_once_lost_its_whole_solid_now_keeps_it() {
+    let ir = decode_file_to_ir(fixture("occt-cylinder.step")).expect("decode occt-cylinder");
+
+    // Not "did it parse" -- did the MANIFOLD_SOLID_BREP survive. A cylinder is
+    // three faces: the lateral surface and two caps.
+    assert_eq!(
+        ir.model.faces.len(),
+        3,
+        "the solid collapsed again: cadmpeg/cadmpeg#79 was one parameter-space \
+         CIRCLE taking the entire MANIFOLD_SOLID_BREP with it"
+    );
+    assert_eq!(ir.model.bodies.len(), 1, "expected one body");
+}


### PR DESCRIPTION
Two STEP readers, on purpose.

Ours (on `step-p21`) stays the default **and stays the measurement baseline**: the
frozen digests, the corpus conversion census and the kernel's failure classes all
describe the B-rep *it* produces. Replacing it is not a dependency swap -- it
invalidates that evidence, mid-campaign. cadmpeg's sits beside it so both can be
run over one corpus and diffed, and a swap becomes a decision with a measurement
behind it, or does not happen.

## The case for cadmpeg got much stronger

Measured 2026-08-06 against cadmpeg 0.4, over the ten in-repo fixtures:

| fixture | bodies/faces/edges/verts | surfaces |
| --- | --- | --- |
| `occt-cube` | 1/6/12/8 | 6 plane -- Euler 8 - 12 + 6 = 2 |
| `occt-cylinder` | 1/3/3/2 | cylinder + 2 plane |
| `occt-assy` | **2** bodies | assemblies survive |
| `abc-0035` | 1/82/188/122 | 38 cylinder, 34 plane, 10 torus |

All ten decode, with **exact analytic carriers** rather than tessellation. On
2026-08-04 `occt-cylinder.step` dropped its entire `MANIFOLD_SOLID_BREP` over one
parameter-space `CIRCLE` -- that was cadmpeg/cadmpeg#79, and cadmpeg/cadmpeg#83
fixed it.

## The test asserts topology, not success

`tests/cadmpeg_reads_the_step_corpus.rs` pins the measured counts exactly. That
matters: a decoder that parses a file and recovers **no faces** has not read it in
any sense a B-rep kernel cares about, and that is precisely how #79 presented --
decode returned `Ok`. The cylinder gets its own row so a regression names the
defect rather than reporting a count mismatch.

## Three things the 0.4 bump surfaced

1. **`cadmpeg-codec-core` was renamed `cadmpeg-core`**, and `ReadSeek` moved with
   it. Depending on both yields two incompatible `ReadSeek` traits and a type
   error that does not mention the rename.
2. **`StepCodec` carries write options**, so it needs `::default()` -- unlike the
   unit-struct `IgesCodec`.
3. **`extern crate self as monstertruck_io`** is only used by
   `monstertruck-derive`'s emitted paths, so it is now gated on `load`. Without
   that gate a cadmpeg-only build fails as an *unused* extern crate under
   `rust_2018_idioms`.

`iges` now implies `cadmpeg` instead of duplicating its dependencies. IGES has no
reader of ours to sit alongside.

## Deliberately not adopted: their writer

Their ladder calls STEP **L9**, which includes source-less generation, and
`write_step` exists. But "writes back a document it decoded" is a weaker claim
than "generates correct STEP from an arbitrary foreign B-rep", which is what
replacing our writer would need. Untested here, so writing stays ours outright.

## Verified

- **All seven feature combinations build**: none, `step`, `cadmpeg`, `iges`, and
  the three unions.
- Default-feature tests unchanged; `cargo clippy --all-targets --all-features`
  clean; workspace check, `fmt --check` and `readme-check` green.