### PR TITLE
Make the randomised tests deterministic, and stop discarding proptest findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,12 @@
 /target
 */target
 Cargo.lock
-*proptest-regressions*
+# proptest failure seeds are NOT ignored: they are findings, not noise.
+# proptest writes them so "everyone who runs the test benefits from these
+# saved cases", and ignoring them means a real counterexample stays on one
+# machine, where it looks like flakiness to everyone else. That is exactly
+# what happened with nurbscurve concat_positive_test. monstertruck-private
+# tracks them already; this aligns.
 
 .bin/
 pkg/

--- a/monstertruck-geometry/tests/nurbscurve.rs
+++ b/monstertruck-geometry/tests/nurbscurve.rs
@@ -103,7 +103,11 @@ proptest! {
     fn concat_positive_test(
         v0 in prop::array::uniform8(prop::array::uniform3(-10f64..10f64)),
         v1 in prop::array::uniform8(0.5f64..=10f64),
-        t in 0f64..=1f64,
+        // Strictly INTERIOR. `cut` at a domain end leaves one piece empty, and
+        // the test's premise -- that the two pieces still meet, `part0.back()`
+        // against `part1.front()` -- has no meaning when one of them has no
+        // back. proptest shrank to exactly `t = 0.0`.
+        t in 1e-3f64..=1.0f64 - 1e-3f64,
         w in -10f64..=10f64,
     ) {
         exec_concat_positive_test(v0, v1, t, w)?;

--- a/monstertruck-traits/tests/curve.rs
+++ b/monstertruck-traits/tests/curve.rs
@@ -2,6 +2,20 @@
 
 use monstertruck_core::{cgmath64::*, tolerance::*};
 use monstertruck_traits::{polynomial::PolynomialCurve, *};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+/// Deterministic generator for the randomised search trials below.
+///
+/// These tests explore a numerical search over random inputs and assert that it
+/// succeeds on most of them. With an unseeded generator that is a coin flip on
+/// every run: the suite fails on its own schedule, for reasons no diff explains,
+/// and a genuine regression is indistinguishable from bad luck. Seeding fixes
+/// the sample, so the trial set is identical on every machine and every run --
+/// the coverage is the same, the verdict is reproducible.
+///
+/// Changing the seed re-rolls the sample and is a real change to what is
+/// measured; do it deliberately, and re-measure the pass counts below.
+fn trial_rng() -> StdRng { StdRng::seed_from_u64(0x5445_5354_5F52_4E47) }
 
 #[test]
 fn polycurve_test() {
@@ -38,20 +52,20 @@ fn polycurve_presearch() {
     assert_eq!(t, 0.0);
 }
 
-fn exec_polycurve_snp_on_curve() -> bool {
+fn exec_polycurve_snp_on_curve(rng: &mut StdRng) -> bool {
     let coef: Vec<Vector3> = (0..5)
         .map(|_| {
             Vector3::new(
-                20.0 * rand::random::<f64>() - 10.0,
-                20.0 * rand::random::<f64>() - 10.0,
-                20.0 * rand::random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
             )
         })
         .collect();
     let poly = PolynomialCurve::<Point3>(coef);
-    let t = 20.0 * rand::random::<f64>() - 10.0;
+    let t = 20.0 * rng.random::<f64>() - 10.0;
     let pt = poly.subs(t);
-    let hint = t + 1.0 * rand::random::<f64>() - 0.5;
+    let hint = t + 1.0 * rng.random::<f64>() - 0.5;
     match algo::curve::search_nearest_parameter(&poly, pt, hint, 100) {
         Some(res) => match poly.subs(res).near(&pt) {
             true => true,
@@ -71,17 +85,25 @@ fn exec_polycurve_snp_on_curve() -> bool {
 
 #[test]
 fn polycurve_snp_on_curve() {
-    let count = (0..100).filter(|_| exec_polycurve_snp_on_curve()).count();
-    assert!(count > 90, "wrong answer: {:?}", 100 - count);
+    let mut rng = trial_rng();
+    let count = (0..100)
+        .filter(|_| exec_polycurve_snp_on_curve(&mut rng))
+        .count();
+    assert_eq!(
+        count,
+        97,
+        "snp_on_curve regressed: {} of 100 failed",
+        100 - count
+    );
 }
 
-fn exec_polycurve_division() -> bool {
+fn exec_polycurve_division(rng: &mut StdRng) -> bool {
     let coef: Vec<Vector3> = (0..5)
         .map(|_| {
             Vector3::new(
-                20.0 * rand::random::<f64>() - 10.0,
-                20.0 * rand::random::<f64>() - 10.0,
-                20.0 * rand::random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
+                20.0 * rng.random::<f64>() - 10.0,
             )
         })
         .collect();
@@ -103,17 +125,25 @@ fn exec_polycurve_division() -> bool {
 
 #[test]
 fn polycurve_division() {
-    let count = (0..100).filter(|_| exec_polycurve_division()).count();
+    let mut rng = trial_rng();
+    let count = (0..100)
+        .filter(|_| exec_polycurve_division(&mut rng))
+        .count();
     println!("division error: {}", 100 - count);
-    assert!(count > 98);
+    assert_eq!(
+        count,
+        100,
+        "division regressed: {} of 100 failed",
+        100 - count
+    );
 }
 
-fn exec_polycurve_closest_point() -> bool {
+fn exec_polycurve_closest_point(rng: &mut StdRng) -> bool {
     let a = [
-        1.0 * rand::random::<f64>() - 0.5,
-        1.0 * rand::random::<f64>() - 0.5,
-        1.0 * rand::random::<f64>() - 0.5,
-        1.0 * rand::random::<f64>() - 0.5,
+        1.0 * rng.random::<f64>() - 0.5,
+        1.0 * rng.random::<f64>() - 0.5,
+        1.0 * rng.random::<f64>() - 0.5,
+        1.0 * rng.random::<f64>() - 0.5,
     ];
     let coef0 = vec![
         Vector3::new(0.0, 0.0, 0.0),
@@ -142,16 +172,24 @@ fn exec_polycurve_closest_point() -> bool {
 
 #[test]
 fn polycurve_closest_point() {
-    let count = (0..10).filter(|_| exec_polycurve_closest_point()).count();
+    let mut rng = trial_rng();
+    let count = (0..10)
+        .filter(|_| exec_polycurve_closest_point(&mut rng))
+        .count();
     println!("searching closest point error: {}", 10 - count);
-    assert!(count >= 7);
+    assert_eq!(
+        count,
+        10,
+        "closest_point regressed: {} of 10 failed",
+        10 - count
+    );
 }
 
-fn exec_polycurve_intersection_point() -> bool {
+fn exec_polycurve_intersection_point(rng: &mut StdRng) -> bool {
     let a = [
-        0.5 * rand::random::<f64>() + 0.1,
-        0.5 * rand::random::<f64>() + 0.1,
-        1.0 * rand::random::<f64>() - 0.5,
+        0.5 * rng.random::<f64>() + 0.1,
+        0.5 * rng.random::<f64>() + 0.1,
+        1.0 * rng.random::<f64>() - 0.5,
     ];
     let (x, y) = (-1.0 + a[0], 1.0 - a[1]);
     let coef0 = vec![
@@ -179,9 +217,15 @@ fn exec_polycurve_intersection_point() -> bool {
 
 #[test]
 fn polycurve_intersection_point() {
+    let mut rng = trial_rng();
     let count = (0..10)
-        .filter(|_| exec_polycurve_intersection_point())
+        .filter(|_| exec_polycurve_intersection_point(&mut rng))
         .count();
     println!("searching intersection point error: {}", 10 - count);
-    assert!(count >= 7);
+    assert_eq!(
+        count,
+        10,
+        "intersection_point regressed: {} of 10 failed",
+        10 - count
+    );
 }

--- a/monstertruck-traits/tests/surface.rs
+++ b/monstertruck-traits/tests/surface.rs
@@ -8,6 +8,20 @@ use monstertruck_core::tolerance::{Origin, Tolerance};
 use monstertruck_traits::algo::surface;
 use monstertruck_traits::polynomial::{PolynomialCurve, PolynomialSurface};
 use monstertruck_traits::{ParametricCurve, ParametricSurface, ParametricSurface3D};
+use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+/// Deterministic generator for the randomised search trials below.
+///
+/// These tests explore a numerical search over random inputs and assert that it
+/// succeeds on most of them. With an unseeded generator that is a coin flip on
+/// every run: the suite fails on its own schedule, for reasons no diff explains,
+/// and a genuine regression is indistinguishable from bad luck. Seeding fixes
+/// the sample, so the trial set is identical on every machine and every run --
+/// the coverage is the same, the verdict is reproducible.
+///
+/// Changing the seed re-rolls the sample and is a real change to what is
+/// measured; do it deliberately, and re-measure the pass counts below.
+fn trial_rng() -> StdRng { StdRng::seed_from_u64(0x5445_5354_5F52_4E47) }
 
 #[test]
 fn polysurface() {
@@ -72,25 +86,25 @@ fn polysurface_presearch() {
     assert_eq!(v, 0.3);
 }
 
-fn exec_polysurface_snp_on_surface() -> bool {
+fn exec_polysurface_snp_on_surface(rng: &mut StdRng) -> bool {
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(1.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 1.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let curve0 = PolynomialCurve::<Point3>(coef0);
     let curve1 = PolynomialCurve::<Point3>(coef1);
     let poly = PolynomialSurface::by_tensor(curve0, curve1);
-    let u = 10.0 * rand::random::<f64>() - 5.0;
-    let v = 10.0 * rand::random::<f64>() - 5.0;
+    let u = 10.0 * rng.random::<f64>() - 5.0;
+    let v = 10.0 * rng.random::<f64>() - 5.0;
     let pt = poly.subs(u, v);
-    let u0 = u + 0.2 * rand::random::<f64>() - 0.1;
-    let v0 = v + 0.2 * rand::random::<f64>() - 0.1;
+    let u0 = u + 0.2 * rng.random::<f64>() - 0.1;
+    let v0 = v + 0.2 * rng.random::<f64>() - 0.1;
     match surface::search_nearest_parameter(&poly, pt, (u0, v0), 100) {
         Some(res) => match poly.subs(res.0, res.1).near(&pt) {
             true => true,
@@ -119,9 +133,10 @@ fn exec_polysurface_snp_on_surface() -> bool {
 
 #[test]
 fn polysurface_snp_on_surface() {
+    let mut rng = trial_rng();
     let flag = (0..10).any(|_| {
         let count = (0..100)
-            .filter(|_| exec_polysurface_snp_on_surface())
+            .filter(|_| exec_polysurface_snp_on_surface(&mut rng))
             .count();
         if count <= 90 {
             eprintln!("wrong answer: {:?}", 100 - count);
@@ -131,27 +146,27 @@ fn polysurface_snp_on_surface() {
     assert!(flag, "too many failure");
 }
 
-fn exec_polysurface_sp_on_surface() -> bool {
+fn exec_polysurface_sp_on_surface(rng: &mut StdRng) -> bool {
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(1.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 1.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
-        Vector3::new(0.0, 0.0, 3.0 * rand::random::<f64>() - 1.5),
+        Vector3::new(1.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 1.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
+        Vector3::new(0.0, 0.0, 3.0 * rng.random::<f64>() - 1.5),
     ];
     let curve0 = PolynomialCurve::<Point3>(coef0);
     let curve1 = PolynomialCurve::<Point3>(coef1);
     let poly = PolynomialSurface::by_tensor(curve0, curve1);
-    let u = 10.0 * rand::random::<f64>() - 5.0;
-    let v = 10.0 * rand::random::<f64>() - 5.0;
+    let u = 10.0 * rng.random::<f64>() - 5.0;
+    let v = 10.0 * rng.random::<f64>() - 5.0;
     let pt = poly.subs(u, v);
-    let u0 = u + 2.0 * rand::random::<f64>() - 1.0;
-    let v0 = v + 2.0 * rand::random::<f64>() - 1.0;
+    let u0 = u + 2.0 * rng.random::<f64>() - 1.0;
+    let v0 = v + 2.0 * rng.random::<f64>() - 1.0;
     match surface::search_parameter(&poly, pt, (u0, v0), 100) {
         Some(res) => match poly.subs(res.0, res.1).near(&pt) {
             true => true,
@@ -180,9 +195,10 @@ fn exec_polysurface_sp_on_surface() -> bool {
 
 #[test]
 fn polysurface_sp_on_surface() {
+    let mut rng = trial_rng();
     let flag = (0..10).any(|_| {
         let count = (0..100)
-            .filter(|_| exec_polysurface_sp_on_surface())
+            .filter(|_| exec_polysurface_sp_on_surface(&mut rng))
             .count();
         if count <= 90 {
             eprintln!("wrong answer: {:?}", 100 - count);
@@ -192,8 +208,8 @@ fn polysurface_sp_on_surface() {
     assert!(flag, "too many failure");
 }
 
-fn exec_polysurface_intersection_point() -> bool {
-    let (a, b) = (rand::random::<f64>(), rand::random::<f64>());
+fn exec_polysurface_intersection_point(rng: &mut StdRng) -> bool {
+    let (a, b) = (rng.random::<f64>(), rng.random::<f64>());
     let coef0 = vec![
         Vector3::new(0.0, 1.0, 0.0),
         Vector3::new(1.0, 0.0, 0.0),
@@ -221,22 +237,28 @@ fn exec_polysurface_intersection_point() -> bool {
 
 #[test]
 fn polysurface_intersection_point() {
+    let mut rng = trial_rng();
     let count = (0..10)
-        .filter(|_| exec_polysurface_intersection_point())
+        .filter(|_| exec_polysurface_intersection_point(&mut rng))
         .count();
-    assert!(count > 7, "wrong answer: {:?}", 10 - count);
+    assert_eq!(
+        count,
+        10,
+        "intersection_point regressed: {} of 10 failed",
+        10 - count
+    );
 }
 
-fn exec_polysurface_division() -> bool {
+fn exec_polysurface_division(rng: &mut StdRng) -> bool {
     let coef0 = vec![
-        Vector3::new(0.0, 1.0, 10.0 * rand::random::<f64>() - 5.0),
-        Vector3::new(1.0, 0.0, 10.0 * rand::random::<f64>() - 5.0),
-        Vector3::new(0.0, 0.0, 10.0 * rand::random::<f64>() - 5.0),
+        Vector3::new(0.0, 1.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(1.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
     ];
     let coef1 = vec![
-        Vector3::new(1.0, 0.0, 10.0 * rand::random::<f64>() - 5.0),
-        Vector3::new(0.0, 1.0, 10.0 * rand::random::<f64>() - 5.0),
-        Vector3::new(0.0, 0.0, 10.0 * rand::random::<f64>() - 5.0),
+        Vector3::new(1.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 1.0, 10.0 * rng.random::<f64>() - 5.0),
+        Vector3::new(0.0, 0.0, 10.0 * rng.random::<f64>() - 5.0),
     ];
     let curve0 = PolynomialCurve::<Point3>(coef0);
     let curve1 = PolynomialCurve::<Point3>(coef1);
@@ -271,8 +293,11 @@ fn exec_polysurface_division() -> bool {
 
 #[test]
 fn polysurface_division() {
-    let count = (0..10).filter(|_| exec_polysurface_division()).count();
-    assert!(count > 8, "wrong answer: {:?}", 10 - count);
+    let mut rng = trial_rng();
+    let count = (0..10)
+        .filter(|_| exec_polysurface_division(&mut rng))
+        .count();
+    assert_eq!(count, 10, "division regressed: {} of 10 failed", 10 - count);
 }
 
 #[test]


### PR DESCRIPTION
Three defects, one theme: tests that fail on their own schedule, for reasons no
diff explains.

## 1. Eight trials drew from an unseeded generator

`monstertruck-traits` explored a numerical search over random inputs and asserted
it succeeded on most attempts -- `count >= 7` of 10, `count > 90` of 100. That is
a coin flip every run: a genuine regression is indistinguishable from bad luck.
One of these, `polycurve_closest_point`, failed during unrelated work and cost a
detour to prove innocent.

All 45 draws now come from one seeded generator per test. **Coverage is
unchanged; only the verdict became reproducible.**

With the sample fixed, the thresholds turned out to be slack -- every one of them
admitted failures the code does not actually have:

| test | was | measured, now |
| --- | --- | --- |
| `polycurve_snp_on_curve` | `> 90` of 100 | `== 97` |
| `polycurve_division` | `> 98` of 100 | `== 100` |
| `polycurve_closest_point` | `>= 7` of 10 | `== 10` |
| `polycurve_intersection_point` | `>= 7` of 10 | `== 10` |
| `polysurface_intersection_point` | `> 7` of 10 | `== 10` |
| `polysurface_division` | `> 8` of 10 | `== 10` |

A threshold that tolerates three failures where there are none would not notice
the first three regressions.

Two `polysurface_*` rows keep their retry-until-one-succeeds shape, but the
generator now sits **outside** the retry closure -- one deterministic stream
feeding ten attempts, rather than the same draw ten times over.

## 2. `concat_positive_test` cut at the domain end

`t in 0f64..=1f64` allowed cutting at `t = 0`, which leaves one piece **empty** --
while the test's premise is that the two pieces still meet, comparing
`part0.back()` against `part1.front()`. A piece with no back has no such point.
`t` is now strictly interior.

**My first diagnosis was wrong, and the record is worth keeping.** I read the
shrunk case as `w = 0.0` -- `w` scales the homogeneous control points, so zero
collapses them -- and bounded `w` away from zero. The seed still failed, and
proptest then shrank `w` to `-0.001`, *exactly* the boundary I had just
introduced, while `t` sat at `0.0`. **Shrinking to the edge of a constraint you
just added is the tell that the constraint is not the cause.** Reverting the `w`
guard and restricting `t` alone fixes it, with `w = 0` still generated and
passing.

## 3. `.gitignore` was discarding proptest findings

`*proptest-regressions*` was ignored. Those files are **findings, not noise** --
proptest writes them so "everyone who runs the test benefits from these saved
cases". Ignoring them means a real counterexample stays on one machine, where it
looks like flakiness to everyone else. That is exactly how the defect in (2)
presented, and it cost two separate detours to establish it was not a regression
I had introduced. `monstertruck-private` tracks them already; this aligns.

## Verified

- three consecutive runs of `monstertruck-traits` + `monstertruck-geometry`:
  **237 tests, all green** -- with the recorded failing seed still present
  locally, so the fix is proven against the actual counterexample;
- ten consecutive runs of the traits suite, 20/20 each time;
- `fmt --check` and clippy clean.