### PR TITLE
Full-boundary NURBS continuity capability inspection (layer 2, rebased)

### DIFF
--- a/monstertruck-geometry/src/nurbs/continuity/mod.rs
+++ b/monstertruck-geometry/src/nurbs/continuity/mod.rs
@@ -1,0 +1,243 @@
+use monstertruck_core::cgmath64::{Homogeneous, control_point::ControlPoint};
+use monstertruck_traits::surface_continuity::{
+    BoundarySide, ContinuityOrder, MAX_CONTINUITY_ORDER, SurfaceContinuityCapability,
+    UnsupportedContinuityCapability,
+};
+
+use super::{BsplineSurface, KnotVector, NurbsSurface};
+
+impl<P: ControlPoint<f64>> BsplineSurface<P> {
+    /// Reports whether this B-spline representation can expose the requested
+    /// derivatives along a full parameter-domain side.
+    ///
+    /// This checks the clamped cross-boundary knot vector, degree, and control
+    /// rows. It does not establish compatibility with another surface or
+    /// feasibility for a numerical solver.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use monstertruck_geometry::prelude::*;
+    ///
+    /// let surface = BsplineSurface::new(
+    ///     (KnotVector::bezier_knot(1), KnotVector::bezier_knot(2)),
+    ///     vec![vec![Point3::new(0.0, 0.0, 0.0); 3]; 2],
+    /// );
+    ///
+    /// let capability =
+    ///     surface.continuity_capability(BoundarySide::MinV, ContinuityOrder::G2);
+    ///
+    /// assert_eq!(capability.unsupported_reason(), None);
+    /// assert_eq!(capability.maximum_supported_order(), Some(ContinuityOrder::G2));
+    /// ```
+    pub fn continuity_capability(
+        &self,
+        side: BoundarySide,
+        requested: ContinuityOrder,
+    ) -> SurfaceContinuityCapability {
+        let control_points = self.control_points();
+        let dimensions = control_points
+            .first()
+            .filter(|row| !row.is_empty())
+            .map(Vec::len)
+            .filter(|&count_v| control_points.iter().all(|row| row.len() == count_v))
+            .map(|count_v| (control_points.len(), count_v));
+
+        match dimensions {
+            Some((count_u, count_v)) => {
+                let (knots, control_count) = match side {
+                    BoundarySide::MinU | BoundarySide::MaxU => (self.knot_vector_u(), count_u),
+                    BoundarySide::MinV | BoundarySide::MaxV => (self.knot_vector_v(), count_v),
+                };
+                capability_for_axis(knots, control_count, side, requested)
+            }
+            None => unsupported(
+                side,
+                requested,
+                UnsupportedContinuityCapability::InvalidControlNet,
+                None,
+            ),
+        }
+    }
+}
+
+impl<V> NurbsSurface<V>
+where V: Homogeneous<Scalar = f64> + ControlPoint<f64, Diff = V>
+{
+    /// Reports whether this positive-weight NURBS representation can expose
+    /// the requested derivatives along a full parameter-domain side.
+    ///
+    /// In addition to the underlying B-spline requirements, every homogeneous
+    /// control point must carry a finite positive weight. This does not
+    /// establish compatibility with another surface or solver feasibility.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use monstertruck_geometry::prelude::*;
+    ///
+    /// let surface = NurbsSurface::new(BsplineSurface::new(
+    ///     (KnotVector::bezier_knot(1), KnotVector::bezier_knot(1)),
+    ///     vec![vec![Vector4::new(0.0, 0.0, 0.0, 1.0); 2]; 2],
+    /// ));
+    ///
+    /// let capability =
+    ///     surface.continuity_capability(BoundarySide::MaxU, ContinuityOrder::G1);
+    ///
+    /// assert_eq!(capability.unsupported_reason(), None);
+    /// ```
+    pub fn continuity_capability(
+        &self,
+        side: BoundarySide,
+        requested: ContinuityOrder,
+    ) -> SurfaceContinuityCapability {
+        let polynomial = self
+            .non_rationalized()
+            .continuity_capability(side, requested);
+        let mut weights = self
+            .control_points()
+            .iter()
+            .flatten()
+            .map(|point| point.weight());
+
+        if polynomial.unsupported_reason().is_some() {
+            polynomial
+        } else if weights.clone().any(|weight| !weight.is_finite()) {
+            unsupported(
+                side,
+                requested,
+                UnsupportedContinuityCapability::NonFiniteWeight,
+                None,
+            )
+        } else if weights.any(|weight| weight <= 0.0) {
+            unsupported(
+                side,
+                requested,
+                UnsupportedContinuityCapability::NonPositiveWeight,
+                None,
+            )
+        } else {
+            polynomial
+        }
+    }
+}
+
+/// Build an unsupported report, asserting the constructor's precondition once.
+///
+/// [`SurfaceContinuityCapability::try_unsupported`] rejects a *known* maximum
+/// order at or above the requested order, because such a report would contradict
+/// itself. Every call below either passes `None` -- structural failures learn
+/// nothing about the achievable order -- or a maximum that the surrounding
+/// insufficiency check has already proven strictly lower. Doing the unwrap here
+/// keeps that argument in one place instead of repeating it at eight call sites.
+fn unsupported(
+    side: BoundarySide,
+    requested: ContinuityOrder,
+    reason: UnsupportedContinuityCapability,
+    maximum_order: Option<ContinuityOrder>,
+) -> SurfaceContinuityCapability {
+    // SAFETY: `maximum_order` is `None`, or strictly below `requested` by the
+    // insufficiency test that selected this reason.
+    SurfaceContinuityCapability::try_unsupported(side, requested, reason, maximum_order).unwrap()
+}
+
+fn capability_for_axis(
+    knots: &KnotVector,
+    control_count: usize,
+    side: BoundarySide,
+    requested: ContinuityOrder,
+) -> SurfaceContinuityCapability {
+    let degree = knots
+        .len()
+        .checked_sub(control_count)
+        .and_then(|difference| difference.checked_sub(1));
+    let values = knots.as_slice();
+    let valid_knots = values.iter().all(|value| value.is_finite())
+        && values.windows(2).all(|pair| pair[0] <= pair[1]);
+    let positive_domain = degree.is_some_and(|degree| {
+        values
+            .get(degree)
+            .zip(values.get(control_count))
+            .is_some_and(|(start, end)| end > start)
+    });
+
+    match degree.filter(|_| valid_knots && positive_domain) {
+        Some(degree) if knots.is_clamped(degree) => {
+            capability_for_degree_and_rows(degree, control_count, side, requested)
+        }
+        Some(_) => unsupported(
+            side,
+            requested,
+            UnsupportedContinuityCapability::UnclampedBoundary,
+            None,
+        ),
+        None => unsupported(
+            side,
+            requested,
+            UnsupportedContinuityCapability::InvalidKnotVector,
+            None,
+        ),
+    }
+}
+
+fn capability_for_degree_and_rows(
+    degree: usize,
+    control_count: usize,
+    side: BoundarySide,
+    requested: ContinuityOrder,
+) -> SurfaceContinuityCapability {
+    let required_degree = requested.as_usize();
+    let required_rows = required_degree + 1;
+    let insufficient_degree = degree < required_degree;
+    let insufficient_rows = control_count < required_rows;
+    let maximum_value = degree
+        .min(control_count.saturating_sub(1))
+        .min(MAX_CONTINUITY_ORDER);
+    let maximum_order = match maximum_value {
+        0 => ContinuityOrder::G0,
+        1 => ContinuityOrder::G1,
+        2 => ContinuityOrder::G2,
+        3 => ContinuityOrder::G3,
+        _ => ContinuityOrder::G4,
+    };
+
+    if insufficient_degree && insufficient_rows {
+        unsupported(
+            side,
+            requested,
+            UnsupportedContinuityCapability::InsufficientDegreeAndControlRows {
+                available_degree: degree,
+                required_degree,
+                available_rows: control_count,
+                required_rows,
+            },
+            Some(maximum_order),
+        )
+    } else if insufficient_degree {
+        unsupported(
+            side,
+            requested,
+            UnsupportedContinuityCapability::InsufficientDegree {
+                available: degree,
+                required: required_degree,
+            },
+            Some(maximum_order),
+        )
+    } else if insufficient_rows {
+        unsupported(
+            side,
+            requested,
+            UnsupportedContinuityCapability::InsufficientControlRows {
+                available: control_count,
+                required: required_rows,
+            },
+            Some(maximum_order),
+        )
+    } else {
+        // SAFETY: Both degree and row checks establish `maximum_order >= requested`.
+        SurfaceContinuityCapability::try_supported_through(side, requested, maximum_order).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/monstertruck-geometry/src/nurbs/continuity/tests.rs
+++ b/monstertruck-geometry/src/nurbs/continuity/tests.rs
@@ -1,0 +1,128 @@
+use monstertruck_core::cgmath64::{Point3, Vector4};
+
+use super::*;
+
+fn polynomial_surface(degree_u: usize, degree_v: usize) -> BsplineSurface<Point3> {
+    let control_points = (0..=degree_u)
+        .map(|u| {
+            (0..=degree_v)
+                .map(|v| Point3::new(u as f64, v as f64, 0.0))
+                .collect()
+        })
+        .collect();
+
+    BsplineSurface::new(
+        (
+            KnotVector::bezier_knot(degree_u),
+            KnotVector::bezier_knot(degree_v),
+        ),
+        control_points,
+    )
+}
+
+#[test]
+fn boundary_side_selects_the_cross_boundary_axis() {
+    let surface = polynomial_surface(1, 3);
+
+    assert_eq!(
+        surface
+            .continuity_capability(BoundarySide::MinV, ContinuityOrder::G3)
+            .unsupported_reason(),
+        None
+    );
+    assert_eq!(
+        surface
+            .continuity_capability(BoundarySide::MinU, ContinuityOrder::G2)
+            .unsupported_reason(),
+        Some(
+            UnsupportedContinuityCapability::InsufficientDegreeAndControlRows {
+                available_degree: 1,
+                required_degree: 2,
+                available_rows: 2,
+                required_rows: 3,
+            }
+        )
+    );
+}
+
+#[test]
+fn unclamped_cross_boundary_axis_is_unsupported() {
+    let surface = BsplineSurface::new(
+        (
+            KnotVector::from(vec![0.0, 1.0, 2.0, 3.0]),
+            KnotVector::bezier_knot(1),
+        ),
+        vec![
+            vec![Point3::new(0.0, 0.0, 0.0); 2],
+            vec![Point3::new(1.0, 0.0, 0.0); 2],
+        ],
+    );
+
+    assert_eq!(
+        surface
+            .continuity_capability(BoundarySide::MaxU, ContinuityOrder::G1)
+            .unsupported_reason(),
+        Some(UnsupportedContinuityCapability::UnclampedBoundary)
+    );
+    assert_eq!(
+        surface
+            .continuity_capability(BoundarySide::MaxV, ContinuityOrder::G1)
+            .unsupported_reason(),
+        None
+    );
+}
+
+#[test]
+fn nurbs_capability_requires_positive_finite_weights() {
+    let positive = NurbsSurface::new(BsplineSurface::new(
+        (KnotVector::bezier_knot(1), KnotVector::bezier_knot(1)),
+        vec![vec![Vector4::new(0.0, 0.0, 0.0, 1.0); 2]; 2],
+    ));
+    let zero_weight = NurbsSurface::new(BsplineSurface::new(
+        (KnotVector::bezier_knot(1), KnotVector::bezier_knot(1)),
+        vec![vec![Vector4::new(0.0, 0.0, 0.0, 0.0); 2]; 2],
+    ));
+
+    assert_eq!(
+        positive
+            .continuity_capability(BoundarySide::MinU, ContinuityOrder::G1)
+            .unsupported_reason(),
+        None
+    );
+    assert_eq!(
+        zero_weight
+            .continuity_capability(BoundarySide::MinU, ContinuityOrder::G0)
+            .unsupported_reason(),
+        Some(UnsupportedContinuityCapability::NonPositiveWeight)
+    );
+}
+
+/// Insufficient degree ALONE, with the control rows adequate.
+///
+/// This is the branch that reports `InsufficientDegree` while still carrying a
+/// known maximum order, so it is the one that would panic if
+/// `try_unsupported`'s precondition -- a known maximum strictly below the
+/// request -- were ever violated. A degree-1 axis with four control rows asked
+/// for `G2` hits it: the rows suffice for `G2`, the degree does not.
+#[test]
+fn insufficient_degree_alone_reports_the_achievable_order() {
+    let surface = BsplineSurface::new(
+        (KnotVector::uniform_knot(1, 3), KnotVector::bezier_knot(2)),
+        vec![vec![Point3::new(0.0, 0.0, 0.0); 3]; 4],
+    );
+
+    let capability = surface.continuity_capability(BoundarySide::MinU, ContinuityOrder::G2);
+
+    assert_eq!(
+        capability.unsupported_reason(),
+        Some(UnsupportedContinuityCapability::InsufficientDegree {
+            available: 1,
+            required: 2,
+        }),
+    );
+    // Strictly below the request, which is what makes the report coherent.
+    assert_eq!(
+        capability.maximum_supported_order(),
+        Some(ContinuityOrder::G1)
+    );
+}

--- a/monstertruck-geometry/src/nurbs/mod.rs
+++ b/monstertruck-geometry/src/nurbs/mod.rs
@@ -255,6 +255,8 @@ pub mod offset;
 
 mod bspline_curve;
 mod bspline_surface;
+/// Full-boundary continuity capability inspection.
+mod continuity;
 mod knot_vector;
 mod nurbs_curve;
 mod nurbs_surface;


### PR DESCRIPTION
@KTheMan's layer-2 slice of the continuity split agreed in #4, rebased onto
current master and migrated to the layer-1 API that #13 actually landed with.
Credit is on the commit.

Adds `BsplineSurface::continuity_capability` and
`NurbsSurface::continuity_capability`: concrete knot-vector, clamping,
cross-boundary degree, control-row, parameter-domain and control-net inspection,
returning a typed reason plus the highest achievable order rather than a bare
bool. NURBS additionally separates non-finite from non-positive homogeneous
weights. Two-surface compatibility and solver feasibility stay out, per the layer
boundary in #4.

## Why it needed changing

Their branch was based on `a60482c3` -- two commits before #13 merged. #13's final
review round, the checked-constructor work, replaced the infallible
`unsupported(..)` with `try_unsupported(..) -> Result`. Layer 2 called the removed
constructor **eight times**:

```
8 x error[E0599]: no associated function or constant named `unsupported`
                  found for struct `SurfaceContinuityCapability`
```

**Nothing on their side could have revealed this.** Their CI is green against
their own base. And because their branch carries layer 1 as a single
`surface_continuity.rs` while master has the `surface_continuity/` **directory**,
git reports no conflict either -- the paths differ. Rust would have seen an
ambiguous module. A green "mergeable" was not evidence here.

## How the migration is done

The eight call sites go through **one local helper** holding a single justified
unwrap, rather than eight scattered ones. `try_unsupported` rejects only a *known*
maximum at or above the request; every site either passes `None` -- a structural
failure learns nothing about the achievable order -- or a maximum the surrounding
insufficiency test has already proven strictly lower. One place to make that
argument, one `// SAFETY:` naming the invariant.

## One test added

The helper introduced a panic path their tests did not reach.
`InsufficientDegreeAndControlRows` was covered; the single-reason
`InsufficientDegree` arm was not, and that is exactly where a wrong invariant
would fire. A degree-1 axis with adequate rows asked for `G2` now pins the
reported achievable order at `G1`.

## Noted, not fixed

`InsufficientControlRows` **alone** appears unreachable: a clamped knot vector
forces `control_count >= degree + 1`, and this arithmetic runs only after
`is_clamped` passes, so an adequate degree implies adequate rows. Harmless
defensive code, but it cannot be exercised through the public entry points.

## Their code, reviewed

The parts most likely to be wrong are not. The axis mapping is correct --
crossing a `MinU`/`MaxU` side means moving in u, so it selects the u knots and u
control rows. The degree relation `knots.len() - control_count - 1` guards
underflow with `checked_sub` into a typed `InvalidKnotVector` rather than
panicking. The order arithmetic is right: degree >= k and k+1 control rows to
control k derivatives. It reuses the existing `KnotVector::is_clamped(degree)`
instead of adding a rival helper.

## Verified

- 245 tests pass, 0 fail; 156 + 2 doctests pass.
- `cargo clippy --workspace --all-targets` clean; `fmt --check` and
  `readme-check` clean.