### PR TITLE
feat(io): the IGES read path converts, instead of returning Unimplemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,36 @@ the two do not line up -- upstream `truck v0.4` has nothing to do with
 monstertruck 0.4.0.
 
 
+## Unreleased
+
+### Added
+
+- **`monstertruck-io`: reading IGES converts, instead of refusing.**
+  `cadmpeg::to_bodies` returned `Error::Unimplemented` at 0.4.0; the decoder and
+  the API were in place but the intermediate representation never reached a B-rep.
+  It now does, behind the `iges` feature.
+
+  Analytic carriers stay analytic: planes, cylinders, cones, spheres and tori
+  reach the same monstertruck variants the STEP loader routes them to, so the
+  closed-form parameter division survives the import. Free-form carriers become
+  B-spline or NURBS depending on whether the source sent weights. Circular edges
+  become exact rational arcs.
+
+  A body, surface or curve this crate cannot represent fails the call and names
+  itself, rather than being dropped from the returned list. Four new typed
+  variants carry those refusals: `UnsupportedSurfaceKind`, `UnsupportedCurveKind`,
+  `DanglingReference` and `MalformedGeometry`. `Error` is `#[non_exhaustive]`, so
+  this is additive.
+
+  Still refused by name, each pending its own work: ellipses, parabolas and
+  hyperbolas; composite curves; periodic NURBS; pole loops at surface
+  singularities; coedge-local (tolerant) edges.
+
+  **The end-to-end path from bytes has no test.** The repository carries no IGES
+  fixture, so the tests build an intermediate representation in memory. They
+  verify the mapping; they do not verify `iges::from_path`.
+
+
 ## 0.4.0 -- 2026-08-17
 
 ### Breaking

--- a/monstertruck-io/src/cadmpeg/convert/curve.rs
+++ b/monstertruck-io/src/cadmpeg/convert/curve.rs
@@ -1,0 +1,282 @@
+//! Curve carriers: intermediate representation to [`Curve`], trimmed to an edge.
+//!
+//! # A curve is converted FOR an edge, never on its own
+//!
+//! monstertruck's [`CompressedEdge`] holds a curve whose own bounded range runs
+//! from the edge's start vertex to its end vertex: `Edge::try_new` checks the
+//! curve's endpoints against the vertices it is given. The intermediate
+//! representation instead stores an UNBOUNDED carrier plus the edge's parameter
+//! interval on it -- a full circle and `[t0, t1]`, an infinite line and two
+//! signed distances.
+//!
+//! So the conversion needs both halves, and the trim is not an afterthought. This
+//! module takes the edge's interval with the carrier, and every arm below returns
+//! a curve already restricted and already oriented start-to-end. Converting the
+//! carrier first and trimming afterwards would need a second parameterization
+//! argument at every call site, and would be wrong for exactly the carriers whose
+//! parameterization is not preserved by the conversion.
+//!
+//! # What the interval means
+//!
+//! Per the representation's own contract, conic parameters are ANGLES from the
+//! reference direction and line parameters are SIGNED DISTANCES along the unit
+//! direction. They are not normalised to `[0, 1]`, and the start vertex lies at
+//! `t0`. A converter that assumed a normalised interval would produce arcs of the
+//! right shape in the wrong place.
+//!
+//! [`CompressedEdge`]: monstertruck_topology::compress::CompressedEdge
+
+use cadmpeg_ir::geometry::{CurveGeometry, NurbsCurve as IrNurbsCurve};
+use monstertruck_geometry::prelude::{
+    BoundedCurve, BsplineCurve, Cut, KnotVector, NurbsCurve, Processor, TrimmedCurve, UnitCircle,
+};
+use monstertruck_modeling::{Curve, Line, Point3, SquareMatrix, Transform as _, Transformed};
+
+use super::surface::{expect_length, homogeneous};
+use super::{Context, frame};
+use crate::{Error, Result};
+
+/// The parameter interval an edge occupies on its carrier, when the file says.
+pub(super) type Interval = Option<[f64; 2]>;
+
+/// Convert one curve carrier, restricted to `interval` and oriented so that the
+/// result runs from the edge's start vertex to its end vertex.
+///
+/// `endpoints` are the edge's own vertex positions. They are the fallback for
+/// carriers whose restriction is determined by its endpoints -- a line -- and they
+/// are never used to REPLACE a stated interval.
+pub(super) fn convert(
+    geometry: &CurveGeometry,
+    interval: Interval,
+    endpoints: (Point3, Point3),
+    context: &Context<'_>,
+) -> Result<Curve> {
+    match geometry {
+        CurveGeometry::Line { origin, direction } => {
+            let origin = frame::point(origin);
+            let direction = frame::vector(direction);
+            match interval {
+                // The stated interval wins: a line's parameter is a signed
+                // distance, so this reproduces the source's own endpoints
+                // exactly, including the case where they sit a tolerance away
+                // from the vertex points.
+                Some([start, end]) => Ok(Curve::Line(Line(
+                    origin + direction * start,
+                    origin + direction * end,
+                ))),
+                // With no interval the vertices ARE the trim, exactly: the
+                // segment between two points on a line is that line's
+                // restriction, with nothing inferred.
+                None => Ok(Curve::Line(Line(endpoints.0, endpoints.1))),
+            }
+        }
+
+        CurveGeometry::Circle {
+            center,
+            axis,
+            ref_direction,
+            radius,
+        } => {
+            let frame = frame::frame(center, axis, ref_direction, "circle", context)?;
+            if !radius.is_finite() || *radius <= 0.0 {
+                return Err(context.malformed(format!("circle has radius {radius}")));
+            }
+            // An arc needs its angles. Without them the carrier is the whole
+            // circle, and which of the two arcs between the vertices the edge
+            // meant is not recoverable -- so this refuses instead of picking one.
+            let Some([start, end]) = interval else {
+                return Err(context.malformed(
+                    "a circular edge carries no parameter range, so which arc between its \
+                     vertices it spans is not recoverable"
+                        .to_owned(),
+                ));
+            };
+            // The radius rides in the placement and the entity stays a UNIT
+            // circle, which is the construction `monstertruck-modeling`'s own
+            // `circle_arc` uses. `TrimmedCurve`'s range is the angle sweep, so a
+            // reversed interval gives the arc traversed the other way and the
+            // endpoints still land on the right vertices.
+            let arc = Processor::with_transform(
+                TrimmedCurve::new(UnitCircle::<Point3>::new(), (start, end)),
+                frame.placement(*radius),
+            );
+            // Exact: a circular arc IS a rational quadratic, so this is a change
+            // of representation and not an approximation.
+            rational(&arc, context)
+        }
+
+        CurveGeometry::Nurbs(curve) => nurbs(curve, interval, context),
+
+        CurveGeometry::Degenerate { .. } => Err(unsupported("degenerate", context)),
+
+        CurveGeometry::Transformed { basis, transform } => {
+            if !transform.is_affine() {
+                return Err(context
+                    .malformed("a transformed curve carries a non-affine placement".to_owned()));
+            }
+            let matrix = frame::matrix(transform);
+            // The endpoints are in MODEL space and the basis carrier is not, so
+            // the fallback endpoints have to be pulled back before the basis is
+            // converted, or a line with no stated interval would be built from
+            // points that are not on it. An affine map is invertible or it is not
+            // a placement.
+            let inverse = matrix.invert().ok_or_else(|| {
+                context.malformed("a transformed curve carries a singular placement".to_owned())
+            })?;
+            let pulled = (
+                inverse.transform_point(endpoints.0),
+                inverse.transform_point(endpoints.1),
+            );
+            let mut curve = convert(basis, interval, pulled, context)?;
+            curve.transform_by(matrix);
+            Ok(curve)
+        }
+
+        // Ellipses, parabolas and hyperbolas are exactly representable as
+        // rational curves in principle, but this crate's geometry has no builder
+        // for them -- only the circle has one -- so admitting them would mean
+        // writing that builder here, unverified, and calling the result exact.
+        // Refused by name until the builder exists next to the circle's.
+        CurveGeometry::Ellipse { .. } => Err(unsupported("elliptical", context)),
+        CurveGeometry::Parabola { .. } => Err(unsupported("parabolic", context)),
+        CurveGeometry::Hyperbola { .. } => Err(unsupported("hyperbolic", context)),
+        // A composite carrier is several curves in one edge; monstertruck's
+        // `CompressedEdge` holds exactly one, so admitting it needs the edge
+        // SPLIT, which is a topology change and not a geometry conversion.
+        CurveGeometry::Composite { .. } => Err(unsupported("composite", context)),
+        CurveGeometry::Procedural { .. } => Err(unsupported("procedural", context)),
+        // An approximation with a chordal bound. Admitting it as a spline would
+        // present a polyline as the exact edge.
+        CurveGeometry::Polyline { .. } => Err(unsupported("source-native polyline", context)),
+        CurveGeometry::Unknown { .. } => Err(unsupported("unclassified native", context)),
+        // Exhaustive on purpose, with no catch-all: see the note in
+        // [`super::surface::convert`].
+    }
+}
+
+fn unsupported(kind: &'static str, context: &Context<'_>) -> Error {
+    Error::UnsupportedCurveKind {
+        format: context.format,
+        kind,
+    }
+}
+
+/// A carrier whose exact form is rational, as a [`Curve::NurbsCurve`].
+fn rational<T>(curve: &T, context: &Context<'_>) -> Result<Curve>
+where T: monstertruck_geometry::prelude::TryIntoHomogeneousBsplineCurve {
+    curve
+        .try_into_homogeneous_bspline_curve()
+        .map(|net| Curve::NurbsCurve(NurbsCurve::new(net)))
+        .ok_or_else(|| {
+            context.malformed(
+                "an exactly-representable curve could not be built, which means its own numbers \
+                 are degenerate"
+                    .to_owned(),
+            )
+        })
+}
+
+/// A free-form curve, restricted to the edge's knot interval.
+fn nurbs(curve: &IrNurbsCurve, interval: Interval, context: &Context<'_>) -> Result<Curve> {
+    let count = curve.control_points.len();
+    if curve.periodic {
+        // Same reasoning as the periodic surface: wrapping the knot vector means
+        // reconstructing control points the file did not send.
+        return Err(unsupported("periodic NURBS", context));
+    }
+    expect_length(
+        curve.knots.len(),
+        count + curve.degree as usize + 1,
+        "NURBS curve knots",
+        context,
+    )?;
+    let knots = KnotVector::from(curve.knots.clone());
+    let mut converted = match &curve.weights {
+        None => Curve::BsplineCurve(built(
+            BsplineCurve::try_new(
+                knots,
+                curve.control_points.iter().map(frame::point).collect(),
+            ),
+            context,
+        )?),
+        Some(weights) => {
+            expect_length(weights.len(), count, "NURBS curve weights", context)?;
+            Curve::NurbsCurve(NurbsCurve::new(built(
+                BsplineCurve::try_new(
+                    knots,
+                    curve
+                        .control_points
+                        .iter()
+                        .zip(weights)
+                        .map(|(point, weight)| homogeneous(point, *weight))
+                        .collect(),
+                ),
+                context,
+            )?))
+        }
+    };
+    // A free-form carrier's parameterization IS preserved by the conversion --
+    // the knot vector carries the source's own knot values -- so the edge's
+    // interval is a knot-span restriction and `Cut` performs it exactly.
+    if let Some([start, end]) = interval {
+        restrict(&mut converted, start, end, context)?;
+    }
+    Ok(converted)
+}
+
+/// Restrict a curve to `[start, end]` on its own parameterization, reversing it
+/// when the edge runs backwards along the carrier.
+///
+/// `Cut` splits in place: after `cut(t)` the receiver covers `[a, t]` and the
+/// returned curve covers `[t, b]`. Two cuts therefore isolate the middle span,
+/// and the order matters -- cutting at the far end first would discard the span
+/// the second cut needs.
+fn restrict(curve: &mut Curve, start: f64, end: f64, context: &Context<'_>) -> Result<()> {
+    let (low, high) = (start.min(end), start.max(end));
+    let (own_low, own_high) = curve.range_tuple();
+    let slack = monstertruck_modeling::TOLERANCE.max((own_high - own_low).abs() * 1.0e-9);
+    if !low.is_finite() || !high.is_finite() {
+        return Err(context.malformed(format!(
+            "an edge carries the parameter range [{start}, {end}]"
+        )));
+    }
+    if low < own_low - slack || high > own_high + slack {
+        // Extrapolating a spline past its knot span is not the same curve, so a
+        // range that leaves the carrier is a defect in the file, not a rounding
+        // question.
+        return Err(context.malformed(format!(
+            "an edge spans [{low}, {high}] on a curve whose own range is [{own_low}, {own_high}]"
+        )));
+    }
+    // Clamp INTO the carrier's range before cutting: a range that is inside it to
+    // within `slack` is the whole carrier, and asking `Cut` for a parameter a few
+    // ulps outside is not defined.
+    let (low, high) = (low.max(own_low), high.min(own_high));
+    if high - own_low < slack || own_high - low < slack {
+        return Err(context.malformed(format!(
+            "an edge spans the empty range [{low}, {high}] on its curve"
+        )));
+    }
+    if own_high - high > slack {
+        let _discarded = curve.cut(high);
+    }
+    if low - own_low > slack {
+        *curve = curve.cut(low);
+    }
+    if end < start {
+        // The edge runs against the carrier's parameter direction. Inverting here
+        // -- rather than leaving it to the coedge's sense -- keeps the invariant
+        // this module promises: the returned curve runs start vertex to end
+        // vertex, so `Edge::try_new` can check it.
+        monstertruck_modeling::Invertible::invert(curve);
+    }
+    Ok(())
+}
+
+/// Turn a geometry-crate construction failure into a typed import failure.
+fn built<T>(
+    result: std::result::Result<T, monstertruck_geometry::errors::Error>,
+    context: &Context<'_>,
+) -> Result<T> {
+    result.map_err(|error| context.malformed(error.to_string()))
+}

--- a/monstertruck-io/src/cadmpeg/convert/frame.rs
+++ b/monstertruck-io/src/cadmpeg/convert/frame.rs
@@ -1,0 +1,133 @@
+//! Placements: turning the intermediate representation's axis-and-reference
+//! triples into the matrices monstertruck's analytic geometry is posed by.
+//!
+//! Every analytic carrier in `cadmpeg-ir` is described the STEP way -- an origin,
+//! an axis, and a zero-azimuth reference direction. monstertruck poses the same
+//! shapes with a [`Matrix4`] on a [`Processor`], or with three points on a
+//! [`Plane`]. This module is the only place that bridges the two, so the
+//! handedness argument below is made once.
+//!
+//! [`Processor`]: monstertruck_geometry::prelude::Processor
+//! [`Plane`]: monstertruck_modeling::Plane
+
+use cadmpeg_ir::math::{Point3 as IrPoint3, Vector3 as IrVector3};
+use cadmpeg_ir::transform::Transform as IrTransform;
+use monstertruck_modeling::{InnerSpace, Matrix4, Point3, Vector3};
+
+use super::Context;
+use crate::Result;
+
+/// Coordinates as monstertruck spells them.
+///
+/// cadmpeg normalises lengths to millimetres on decode, so there is no unit
+/// factor to apply here -- see the module note on [`crate::cadmpeg`].
+pub(super) fn point(value: &IrPoint3) -> Point3 { Point3::new(value.x, value.y, value.z) }
+
+/// A direction as monstertruck spells it, not yet normalised.
+pub(super) fn vector(value: &IrVector3) -> Vector3 { Vector3::new(value.x, value.y, value.z) }
+
+/// A row-major intermediate-representation transform as a column-major
+/// [`Matrix4`].
+///
+/// `Transform::rows[i][j]` is row `i`, column `j`; [`Matrix4::from_cols`] wants
+/// columns. Getting this backwards transposes every placement, which for a rigid
+/// motion inverts the rotation and leaves the translation in the wrong row -- so
+/// it is not the kind of mistake that shows up as a small error.
+pub(super) fn matrix(value: &IrTransform) -> Matrix4 {
+    let rows = &value.rows;
+    let column = |index: usize| {
+        monstertruck_modeling::Vector4::new(
+            rows[0][index],
+            rows[1][index],
+            rows[2][index],
+            rows[3][index],
+        )
+    };
+    Matrix4::from_cols(column(0), column(1), column(2), column(3))
+}
+
+/// A right-handed orthonormal placement: where a carrier sits, which way its
+/// axis points, and where its parameter zero is.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Frame {
+    /// The carrier's origin or centre.
+    pub(super) origin: Point3,
+    /// Unit axis.
+    pub(super) axis: Vector3,
+    /// Unit zero-azimuth direction, perpendicular to [`Frame::axis`].
+    pub(super) reference: Vector3,
+}
+
+impl Frame {
+    /// The third axis, completing a right-handed triple.
+    pub(super) fn co_reference(&self) -> Vector3 { self.axis.cross(self.reference) }
+
+    /// The matrix that maps the canonical frame -- x to `reference`, y to
+    /// `axis x reference`, z to `axis`, origin to `origin` -- into place, with
+    /// `scale` applied to the two radial columns.
+    ///
+    /// Scaling the radial columns is what turns a UNIT circle into a circle of a
+    /// given radius without touching the entity, which is how monstertruck's
+    /// exact conics are built: the radius lives in the placement, and the entity
+    /// stays canonical and exactly representable.
+    pub(super) fn placement(&self, scale: f64) -> Matrix4 {
+        let radial = self.reference * scale;
+        Matrix4::from_cols(
+            radial.extend(0.0),
+            (self.axis.cross(radial)).extend(0.0),
+            self.axis.extend(0.0),
+            self.origin.to_homogeneous(),
+        )
+    }
+}
+
+/// Build a frame, refusing rather than guessing when the source directions do
+/// not define one.
+///
+/// Two things are checked, and both are real in exported files:
+///
+/// * a zero-length axis or reference, which no amount of normalising fixes;
+/// * a reference direction PARALLEL to the axis, which leaves the azimuth
+///   undetermined.
+///
+/// The reference direction is projected perpendicular to the axis rather than
+/// used as given. Exporters are entitled to emit a reference that is only
+/// approximately perpendicular, and Gram-Schmidt against the axis is what STEP's
+/// own `axis2_placement_3d` semantics prescribe.
+pub(super) fn frame(
+    origin: &IrPoint3,
+    axis: &IrVector3,
+    reference: &IrVector3,
+    what: &str,
+    context: &Context<'_>,
+) -> Result<Frame> {
+    let axis = vector(axis);
+    let reference = vector(reference);
+    if !axis.magnitude2().is_finite() || axis.magnitude2() <= 0.0 {
+        return Err(context.malformed(format!("{what} has a zero-length or non-finite axis")));
+    }
+    let axis = axis.normalize();
+    let radial = reference - axis * axis.dot(reference);
+    if !radial.magnitude2().is_finite() || radial.magnitude2() <= 0.0 {
+        return Err(context.malformed(format!(
+            "{what} has a reference direction parallel to its axis, so its zero azimuth is \
+             undetermined"
+        )));
+    }
+    Ok(Frame {
+        origin: point(origin),
+        axis,
+        reference: radial.normalize(),
+    })
+}
+
+/// A frame for a carrier described by a normal and an in-plane direction, which
+/// is how the intermediate representation spells a plane.
+pub(super) fn plane_frame(
+    origin: &IrPoint3,
+    normal: &IrVector3,
+    u_axis: &IrVector3,
+    context: &Context<'_>,
+) -> Result<Frame> {
+    frame(origin, normal, u_axis, "plane", context)
+}

--- a/monstertruck-io/src/cadmpeg/convert/mod.rs
+++ b/monstertruck-io/src/cadmpeg/convert/mod.rs
@@ -1,0 +1,228 @@
+//! The converter: [`cadmpeg_ir::CadIr`] to monstertruck bodies.
+//!
+//! # Nothing is dropped
+//!
+//! [`convert`] returns a `Vec`, and a `Vec` cannot say "one of these was left
+//! out". Handing back three bodies for a file that holds five is the worst
+//! available outcome: the caller sees success, gets geometry, and has no way to
+//! learn what is missing. So every body converts or the whole call fails, and the
+//! failure names the kind that caused it. `iges::from_path` returning an error you
+//! can act on beats a solid with a face quietly absent from it.
+//!
+//! This is why there is no `skip` path anywhere below, and why the refusals in
+//! [`surface`], [`curve`] and [`topology`] are typed errors rather than `None`.
+
+mod frame;
+
+pub(super) mod curve;
+pub(super) mod surface;
+pub(super) mod topology;
+
+#[cfg(test)]
+mod tests;
+
+use cadmpeg_ir::geometry::{Curve as IrCurve, Surface as IrSurface};
+use cadmpeg_ir::index::ModelIndex;
+use cadmpeg_ir::topology::{
+    BodyKind, Coedge, Edge as IrEdge, Face as IrFace, Loop as IrLoop, Point as IrPoint,
+    Vertex as IrVertex,
+};
+
+use super::{ImportedBody, ImportedSheet, ImportedSolid};
+use crate::{Error, Result};
+
+/// What a conversion needs to know throughout: the indexed document and which
+/// format it came from.
+///
+/// The format name is carried so every refusal says `IGES carried a ...` rather
+/// than making the caller guess which of two readers produced it.
+pub(super) struct Context<'a> {
+    index: ModelIndex<'a>,
+    format: &'static str,
+}
+
+impl<'a> Context<'a> {
+    fn malformed(&self, detail: String) -> Error {
+        Error::MalformedGeometry {
+            format: self.format,
+            detail,
+        }
+    }
+
+    fn dangling(&self, kind: &'static str, id: &str) -> Error {
+        Error::DanglingReference {
+            format: self.format,
+            kind,
+            id: id.to_owned(),
+        }
+    }
+}
+
+/// Resolve one reference, or report which table it dangled out of.
+///
+/// A macro rather than a generic function because `ModelIndex`'s accessors are
+/// one per table, generated from the same declaration as the tables themselves.
+macro_rules! resolvers {
+    ($($method:ident -> $table:ident: $entity:ty, $kind:literal;)*) => {
+        impl<'a> Context<'a> {
+            $(
+                fn $method(&self, id: &str) -> Result<&'a $entity> {
+                    self.index.$table(id).ok_or_else(|| self.dangling($kind, id))
+                }
+            )*
+        }
+    };
+}
+
+resolvers! {
+    face -> faces: IrFace, "face";
+    boundary_loop -> loops: IrLoop, "loop";
+    coedge -> coedges: Coedge, "coedge";
+    edge -> edges: IrEdge, "edge";
+    vertex -> vertices: IrVertex, "vertex";
+    point -> points: IrPoint, "point";
+    surface -> surfaces: IrSurface, "surface";
+    curve -> curves: IrCurve, "curve";
+}
+
+/// Convert every body in a decoded document.
+pub(super) fn convert(ir: &cadmpeg_ir::CadIr, format: &'static str) -> Result<Vec<ImportedBody>> {
+    let context = Context {
+        index: ModelIndex::new(ir),
+        format,
+    };
+    ir.model
+        .bodies
+        .iter()
+        .map(|body| body_to_imported(body, &context))
+        .collect()
+}
+
+fn body_to_imported(
+    body: &cadmpeg_ir::topology::Body,
+    context: &Context<'_>,
+) -> Result<ImportedBody> {
+    match body.kind {
+        BodyKind::Solid => Ok(ImportedBody::Solid(solid(body, context)?)),
+        BodyKind::Sheet => Ok(ImportedBody::Sheet(sheet(body, context)?)),
+        // A wire body is a curve collection with no faces, and a `General` body
+        // mixes dimensions. Neither has a compressed form. Named, not dropped.
+        BodyKind::Wire => Err(Error::UnsupportedBodyKind {
+            format: context.format,
+            kind: "wire",
+        }),
+        BodyKind::General => Err(Error::UnsupportedBodyKind {
+            format: context.format,
+            kind: "mixed-dimensional",
+        }),
+        // Exhaustive on purpose: see the note in [`surface::convert`].
+    }
+}
+
+/// A solid: one compressed shell per source shell, because for a body that bounds
+/// a volume the shell partition IS the difference between the outer surface and a
+/// void.
+fn solid(body: &cadmpeg_ir::topology::Body, context: &Context<'_>) -> Result<ImportedSolid> {
+    let mut boundaries = Vec::new();
+    for region in &body.regions {
+        let region = context
+            .index
+            .regions(region.as_str())
+            .ok_or_else(|| context.dangling("region", region.as_str()))?;
+        for shell in &region.shells {
+            let shell = context
+                .index
+                .shells(shell.as_str())
+                .ok_or_else(|| context.dangling("shell", shell.as_str()))?;
+            let mut builder = topology::ShellBuilder::new(context);
+            builder.add_shell(shell)?;
+            if builder.is_empty() {
+                return Err(context.malformed(format!(
+                    "solid body {} has a shell with no faces, so it bounds no volume",
+                    body.id
+                )));
+            }
+            boundaries.push(builder.finish());
+        }
+    }
+    if boundaries.is_empty() {
+        return Err(context.malformed(format!("solid body {} carries no boundary shell", body.id)));
+    }
+    let mut solid = ImportedSolid {
+        boundaries,
+        id_allocator: None,
+        attributes: None,
+    };
+    if let Some(transform) = &body.transform {
+        place_solid(&mut solid, transform, context)?;
+    }
+    Ok(solid)
+}
+
+/// A sheet: every shell of the body merged into one compressed shell.
+///
+/// See [`topology::ShellBuilder::add_shell`] for why merging is right here and
+/// wrong for a solid.
+fn sheet(body: &cadmpeg_ir::topology::Body, context: &Context<'_>) -> Result<ImportedSheet> {
+    let mut builder = topology::ShellBuilder::new(context);
+    for region in &body.regions {
+        let region = context
+            .index
+            .regions(region.as_str())
+            .ok_or_else(|| context.dangling("region", region.as_str()))?;
+        for shell in &region.shells {
+            let shell = context
+                .index
+                .shells(shell.as_str())
+                .ok_or_else(|| context.dangling("shell", shell.as_str()))?;
+            builder.add_shell(shell)?;
+        }
+    }
+    if builder.is_empty() {
+        return Err(context.malformed(format!("sheet body {} carries no face", body.id)));
+    }
+    let mut sheet = builder.finish();
+    if let Some(transform) = &body.transform {
+        place_shell(&mut sheet, transform, context)?;
+    }
+    Ok(sheet)
+}
+
+/// Apply a body's world placement.
+///
+/// A body transform is a placement of the body's geometry, so it applies to every
+/// vertex, curve and surface in it. Leaving it out puts a correctly-shaped body at
+/// the origin instead of where the assembly says it is -- which is a silent wrong
+/// answer, not a visible failure.
+fn place_solid(
+    solid: &mut ImportedSolid,
+    transform: &cadmpeg_ir::transform::Transform,
+    context: &Context<'_>,
+) -> Result<()> {
+    for shell in &mut solid.boundaries {
+        place_shell(shell, transform, context)?;
+    }
+    Ok(())
+}
+
+fn place_shell(
+    shell: &mut ImportedSheet,
+    transform: &cadmpeg_ir::transform::Transform,
+    context: &Context<'_>,
+) -> Result<()> {
+    use monstertruck_modeling::{Transform as _, Transformed};
+    if !transform.is_affine() {
+        return Err(context.malformed("a body carries a non-affine placement".to_owned()));
+    }
+    let matrix = frame::matrix(transform);
+    for vertex in &mut shell.vertices {
+        *vertex = matrix.transform_point(*vertex);
+    }
+    for edge in &mut shell.edges {
+        edge.curve.transform_by(matrix);
+    }
+    for face in &mut shell.faces {
+        face.surface.transform_by(matrix);
+    }
+    Ok(())
+}

--- a/monstertruck-io/src/cadmpeg/convert/surface.rs
+++ b/monstertruck-io/src/cadmpeg/convert/surface.rs
@@ -1,0 +1,331 @@
+//! Surface carriers: intermediate representation to [`Surface`].
+//!
+//! # Analytic carriers stay analytic
+//!
+//! Which variant an analytic surface lands on is a decision with consequences,
+//! not a formality. monstertruck keeps spheres and tori as their analytic types
+//! rather than as their (exact) rational nets so that the CLOSED-FORM parameter
+//! division and the analytic `search_parameter` survive the import -- spec 012
+//! U1.2. Routing them onto a net instead is exact in the forward direction and
+//! wrong in the inverse one, which is the direction that places face trims.
+//!
+//! The routing here is the one
+//! `monstertruck-io/src/step/load/step_geometry/geom_impls/to_modeling.rs` makes
+//! for STEP, restated for a different input vocabulary. It is NOT a second
+//! opinion about which surfaces are exactly representable.
+//!
+//! # How the degenerate cases are refused
+//!
+//! The STEP path guards its analytic arms with predicates that restate the
+//! builder's own admissibility rules -- a spindle torus must not reach the
+//! analytic variant, because on one `search_parameter` is wrong over ~29% of the
+//! domain. Restating a predicate is exactly the thing that drifts, and this
+//! module cannot even share the STEP one: `iges` does not imply the `step`
+//! feature.
+//!
+//! So this module does not restate it. It builds the analytic carrier, then ASKS
+//! THE BUILDER by probing [`TryIntoHomogeneousBsplineSurface`]. A carrier the
+//! builder refuses to net is a carrier whose analytic form is not admissible, and
+//! the probe is the predicate rather than a copy of it. One throwaway net per
+//! analytic surface is the price, and it cannot drift.
+
+use cadmpeg_ir::geometry::{NurbsSurface as IrNurbsSurface, SurfaceGeometry};
+use monstertruck_geometry::prelude::{
+    BsplineSurface, KnotVector, NurbsSurface, Processor, RevolutionSurface, Sphere, Torus,
+    TryIntoHomogeneousBsplineSurface,
+};
+use monstertruck_modeling::{
+    Curve, EuclideanSpace, Line, Plane, Point3, Surface, Transformed, Vector4,
+};
+
+use super::{Context, frame};
+use crate::Result;
+
+/// Convert one surface carrier.
+pub(super) fn convert(geometry: &SurfaceGeometry, context: &Context<'_>) -> Result<Surface> {
+    match geometry {
+        SurfaceGeometry::Plane {
+            origin,
+            normal,
+            u_axis,
+        } => {
+            let frame = frame::plane_frame(origin, normal, u_axis, context)?;
+            // Three points, not a normal: `Plane` stores its own u and v axes, and
+            // taking v as `axis x u` keeps the plane's normal equal to the source
+            // normal. Swapping the two would flip every face on it.
+            Ok(Surface::Plane(Plane::new(
+                frame.origin,
+                frame.origin + frame.reference,
+                frame.origin + frame.co_reference(),
+            )))
+        }
+
+        SurfaceGeometry::Cylinder {
+            origin,
+            axis,
+            ref_direction,
+            radius,
+        } => {
+            let frame = frame::frame(origin, axis, ref_direction, "cylinder", context)?;
+            let radius = finite_radius(*radius, "cylinder", context)?;
+            // A cylinder is a line at distance `radius` from the axis, revolved.
+            // The profile is UNIT length: the surface is unbounded along its axis
+            // and the profile's own range is incidental, which is exactly what
+            // STEP's `CYLINDRICAL_SURFACE` also produces. Consumers that need the
+            // real extent pass the face's trim rectangle to
+            // `try_into_homogeneous_bspline_surface_over`.
+            let base = frame.origin + frame.reference * radius;
+            revolution(Line(base, base + frame.axis), frame)
+        }
+
+        SurfaceGeometry::Cone {
+            origin,
+            axis,
+            ref_direction,
+            radius,
+            ratio,
+            half_angle,
+        } => {
+            // An ELLIPTICAL cone is not a surface of revolution, so it has no
+            // `RevolutionSurface` form and no other exact one either. Refused by
+            // name rather than silently converted into the circular cone that
+            // `ratio == 1` would have meant.
+            if (ratio - 1.0).abs() > f64::EPSILON.sqrt() {
+                return Err(crate::Error::UnsupportedSurfaceKind {
+                    format: context.format,
+                    kind: "elliptical cone",
+                });
+            }
+            let frame = frame::frame(origin, axis, ref_direction, "cone", context)?;
+            let radius = finite_radius(*radius, "cone", context)?;
+            let taper = half_angle.tan();
+            if !taper.is_finite() {
+                return Err(context.malformed(format!(
+                    "cone half-angle {half_angle} radians has no finite taper, so its profile is \
+                     parallel to its own axis"
+                )));
+            }
+            let base = frame.origin + frame.reference * radius;
+            let apex_ward = frame.axis + frame.reference * taper;
+            revolution(Line(base, base + apex_ward), frame)
+        }
+
+        SurfaceGeometry::Sphere { center, radius, .. } => {
+            // `axis` and `ref_direction` are deliberately dropped. They fix the
+            // sphere's parameterization, not its point set, and a sphere's point
+            // set is invariant under rotation about its own centre. Nothing
+            // downstream reads the intermediate representation's parameter-space
+            // curves -- `CompressedFace` has nowhere to store them and every
+            // consumer re-derives (u, v) by projecting the 3D boundary -- so any
+            // valid parameterization of the right point set is the right answer.
+            // Keeping the source frame instead would cost a `Processor` transform
+            // on every sphere and buy nothing.
+            let radius = finite_radius(*radius, "sphere", context)?;
+            let sphere = Processor::new(Sphere::new(frame::point(center), radius));
+            admissible(&sphere, "sphere", context)?;
+            Ok(Surface::SphericalSurface(sphere))
+        }
+
+        SurfaceGeometry::Torus {
+            center,
+            axis,
+            ref_direction,
+            major_radius,
+            minor_radius,
+        } => {
+            // Unlike a sphere, a torus's point set DOES depend on its axis, so
+            // the frame is carried in the `Processor`'s transform and the entity
+            // stays canonical.
+            let frame = frame::frame(center, axis, ref_direction, "torus", context)?;
+            let major = finite_radius(*major_radius, "torus major radius", context)?;
+            let minor = finite_radius(*minor_radius, "torus minor radius", context)?;
+            // `Torus::new` PANICS on a non-positive radius. `finite_radius` has
+            // already refused those, so this call cannot reach the panic -- which
+            // is the point of checking here rather than trusting the file.
+            let torus = Processor::with_transform(
+                Torus::new(Point3::origin(), major, minor),
+                frame.placement(1.0),
+            );
+            admissible(&torus, "torus", context)?;
+            Ok(Surface::ToroidalSurface(torus))
+        }
+
+        SurfaceGeometry::Nurbs(surface) => nurbs(surface, context),
+
+        SurfaceGeometry::Transformed { basis, transform } => {
+            let mut surface = convert(basis, context)?;
+            if !transform.is_affine() {
+                return Err(context
+                    .malformed("a transformed surface carries a non-affine placement".to_owned()));
+            }
+            surface.transform_by(frame::matrix(transform));
+            Ok(surface)
+        }
+
+        // Refused by name, every one of them. A `Procedural` carrier names a
+        // construction this crate would have to replay; `Polygonal` is an
+        // approximation with a chordal bound, and admitting it as a spline patch
+        // would present a tessellation as exact geometry; `Unknown` is bytes the
+        // decoder itself could not classify.
+        SurfaceGeometry::Procedural { .. } => Err(unsupported("procedural", context)),
+        SurfaceGeometry::Polygonal { .. } => Err(unsupported("source-native polygonal", context)),
+        SurfaceGeometry::Unknown { .. } => Err(unsupported("unclassified native", context)),
+        // Matched EXHAUSTIVELY, with no catch-all. `SurfaceGeometry` is not
+        // `#[non_exhaustive]`, so a cadmpeg release that adds a carrier breaks
+        // this build -- which is what we want. A catch-all would turn that
+        // release into a silent runtime refusal for a surface someone then has to
+        // discover is unsupported, instead of a decision made when the dependency
+        // moves.
+    }
+}
+
+/// Revolve a profile line about a frame's axis.
+fn revolution(profile: Line<Point3>, frame: frame::Frame) -> Result<Surface> {
+    Ok(Surface::RevolutionSurface(Processor::new(
+        RevolutionSurface::by_revolution(Curve::Line(profile), frame.origin, frame.axis),
+    )))
+}
+
+/// A radius that can actually be built with.
+fn finite_radius(radius: f64, what: &str, context: &Context<'_>) -> Result<f64> {
+    if !radius.is_finite() || radius <= 0.0 {
+        return Err(context.malformed(format!("{what} has radius {radius}")));
+    }
+    Ok(radius)
+}
+
+/// Ask the net builder whether this analytic carrier is admissible.
+///
+/// See the module note: the builder's refusal IS the predicate, so probing it
+/// cannot drift from it the way a restated guard can.
+fn admissible<T: TryIntoHomogeneousBsplineSurface>(
+    surface: &T,
+    what: &'static str,
+    context: &Context<'_>,
+) -> Result<()> {
+    match surface.try_into_homogeneous_bspline_surface() {
+        Some(_) => Ok(()),
+        None => Err(crate::Error::UnsupportedSurfaceKind {
+            format: context.format,
+            kind: match what {
+                "torus" => "degenerate torus",
+                other => other,
+            },
+        }),
+    }
+}
+
+fn unsupported(kind: &'static str, context: &Context<'_>) -> crate::Error {
+    crate::Error::UnsupportedSurfaceKind {
+        format: context.format,
+        kind,
+    }
+}
+
+/// A free-form surface, rational or not.
+///
+/// Non-rational nets become [`Surface::BsplineSurface`] rather than a
+/// [`Surface::NurbsSurface`] with every weight at one: the polynomial form has no
+/// weight division in its evaluation, and the boolean kernel's exact-patch
+/// machinery distinguishes the two.
+fn nurbs(surface: &IrNurbsSurface, context: &Context<'_>) -> Result<Surface> {
+    let (rows, columns) = (surface.u_count as usize, surface.v_count as usize);
+    if surface.u_periodic || surface.v_periodic {
+        // A periodic knot vector is not a clamped one, and wrapping it correctly
+        // means reconstructing control points the source did not send. Refused
+        // rather than built with a seam in the wrong place.
+        return Err(crate::Error::UnsupportedSurfaceKind {
+            format: context.format,
+            kind: "periodic NURBS",
+        });
+    }
+    expect_length(
+        surface.control_points.len(),
+        rows * columns,
+        "NURBS surface control points",
+        context,
+    )?;
+    expect_length(
+        surface.u_knots.len(),
+        rows + surface.u_degree as usize + 1,
+        "NURBS surface u knots",
+        context,
+    )?;
+    expect_length(
+        surface.v_knots.len(),
+        columns + surface.v_degree as usize + 1,
+        "NURBS surface v knots",
+        context,
+    )?;
+    let knots = (
+        KnotVector::from(surface.u_knots.clone()),
+        KnotVector::from(surface.v_knots.clone()),
+    );
+    // Control points arrive u-major: index `i * v_count + j` is pole (i, j),
+    // which is the row-of-v layout `BsplineSurface` wants.
+    let rows_of = |row: usize| &surface.control_points[row * columns..(row + 1) * columns];
+    match &surface.weights {
+        None => {
+            let net = (0..rows)
+                .map(|row| rows_of(row).iter().map(frame::point).collect())
+                .collect();
+            Ok(Surface::BsplineSurface(built(
+                BsplineSurface::try_new(knots, net),
+                context,
+            )?))
+        }
+        Some(weights) => {
+            expect_length(
+                weights.len(),
+                rows * columns,
+                "NURBS surface weights",
+                context,
+            )?;
+            let net = (0..rows)
+                .map(|row| {
+                    rows_of(row)
+                        .iter()
+                        .zip(&weights[row * columns..(row + 1) * columns])
+                        .map(|(point, weight)| homogeneous(point, *weight))
+                        .collect()
+                })
+                .collect();
+            Ok(Surface::NurbsSurface(NurbsSurface::new(built(
+                BsplineSurface::try_new(knots, net),
+                context,
+            )?)))
+        }
+    }
+}
+
+/// A rational control point in homogeneous coordinates.
+pub(super) fn homogeneous(point: &cadmpeg_ir::math::Point3, weight: f64) -> Vector4 {
+    Vector4::new(point.x * weight, point.y * weight, point.z * weight, weight)
+}
+
+/// Report a count mismatch as malformed geometry rather than panicking in the
+/// slice arithmetic below it.
+pub(super) fn expect_length(
+    actual: usize,
+    expected: usize,
+    what: &str,
+    context: &Context<'_>,
+) -> Result<()> {
+    if actual != expected {
+        return Err(context.malformed(format!(
+            "{what}: expected {expected} values, the file carried {actual}"
+        )));
+    }
+    Ok(())
+}
+
+/// Turn a geometry-crate construction failure into a typed import failure.
+///
+/// `BsplineSurface::new` panics where `try_new` reports; on file input the
+/// reporting one is the only defensible choice.
+fn built<T>(
+    result: std::result::Result<T, monstertruck_geometry::errors::Error>,
+    context: &Context<'_>,
+) -> Result<T> {
+    result.map_err(|error| context.malformed(error.to_string()))
+}

--- a/monstertruck-io/src/cadmpeg/convert/tests.rs
+++ b/monstertruck-io/src/cadmpeg/convert/tests.rs
@@ -1,0 +1,1170 @@
+//! Conversion tests over an IN-MEMORY intermediate representation.
+//!
+//! No IGES file is read here, deliberately. The decoder is cadmpeg's
+//! responsibility and is already measured (see the note on [`crate::cadmpeg`]);
+//! what is unverified is this crate's mapping, and building the representation
+//! directly is the only way to exercise a refusal arm for a carrier no fixture in
+//! the world happens to contain.
+//!
+//! **These tests do not show that reading an IGES file works.** They show that a
+//! decoded document converts. The end-to-end path has no test until the repository
+//! carries an IGES fixture of its own -- spec 028 slice 3.
+
+use cadmpeg_ir::geometry::{
+    Curve as IrCurve, CurveGeometry, NurbsCurve as IrNurbsCurve, Surface as IrSurface,
+    SurfaceGeometry,
+};
+use cadmpeg_ir::math::{Point3 as IrPoint3, Vector3 as IrVector3};
+use cadmpeg_ir::topology::{
+    Body, BodyKind, Coedge, Edge as IrEdge, Face as IrFace, Loop as IrLoop, LoopBoundaryRole,
+    Point as IrPoint, Region, Sense, Shell as IrShell, Vertex as IrVertex,
+};
+use monstertruck_modeling::{
+    BoundedCurve, EuclideanSpace, InnerSpace, MetricSpace, ParametricCurve, ParametricSurface,
+    Point3, Surface, Transform as _,
+};
+use monstertruck_topology::compress::CompressedEdgeIndex;
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// Building a document by hand.
+// ---------------------------------------------------------------------------
+
+/// A minimal document under construction.
+///
+/// Every helper returns the id it just added, so a test reads as the graph it
+/// builds rather than as a wall of string literals.
+struct Builder {
+    ir: cadmpeg_ir::CadIr,
+    counter: usize,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            ir: empty_document(),
+            counter: 0,
+        }
+    }
+}
+
+impl Builder {
+    fn id(&mut self, prefix: &str) -> String {
+        self.counter += 1;
+        format!("{prefix}{}", self.counter)
+    }
+
+    fn point(&mut self, x: f64, y: f64, z: f64) -> String {
+        let id = self.id("point");
+        self.ir.model.points.push(IrPoint {
+            id: id.clone().into(),
+            position: IrPoint3::new(x, y, z),
+            source_object: None,
+        });
+        id
+    }
+
+    fn vertex(&mut self, x: f64, y: f64, z: f64) -> String {
+        let point = self.point(x, y, z);
+        let id = self.id("vertex");
+        self.ir.model.vertices.push(IrVertex {
+            id: id.clone().into(),
+            point: point.into(),
+            tolerance: None,
+        });
+        id
+    }
+
+    fn surface(&mut self, geometry: SurfaceGeometry) -> String {
+        let id = self.id("surface");
+        self.ir.model.surfaces.push(IrSurface {
+            id: id.clone().into(),
+            geometry,
+            source_object: None,
+        });
+        id
+    }
+
+    fn curve(&mut self, geometry: CurveGeometry) -> String {
+        let id = self.id("curve");
+        self.ir.model.curves.push(IrCurve {
+            id: id.clone().into(),
+            geometry,
+            source_object: None,
+        });
+        id
+    }
+
+    fn edge(
+        &mut self,
+        curve: Option<&str>,
+        start: &str,
+        end: &str,
+        range: Option<[f64; 2]>,
+    ) -> String {
+        let id = self.id("edge");
+        self.ir.model.edges.push(IrEdge {
+            id: id.clone().into(),
+            curve: curve.map(Into::into),
+            start: start.into(),
+            end: end.into(),
+            param_range: range,
+            tolerance: None,
+        });
+        id
+    }
+
+    /// A closed ring of coedges over `edges`, all forward, on one loop.
+    fn ring(&mut self, face: &str, role: LoopBoundaryRole, edges: &[String]) -> String {
+        self.ring_with_senses(
+            face,
+            role,
+            &edges
+                .iter()
+                .map(|edge| (edge.clone(), Sense::Forward))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn ring_with_senses(
+        &mut self,
+        face: &str,
+        role: LoopBoundaryRole,
+        edges: &[(String, Sense)],
+    ) -> String {
+        let loop_id = self.id("loop");
+        // The coedge ids have to be known before the ring can be linked, so they
+        // are allocated first and the `next`/`previous` cycle closed afterwards.
+        let coedge_ids: Vec<String> = (0..edges.len()).map(|_| self.id("coedge")).collect();
+        let count = coedge_ids.len();
+        for (position, (edge, sense)) in edges.iter().enumerate() {
+            self.ir.model.coedges.push(Coedge {
+                id: coedge_ids[position].clone().into(),
+                owner_loop: loop_id.clone().into(),
+                edge: edge.clone().into(),
+                next: coedge_ids[(position + 1) % count].clone().into(),
+                previous: coedge_ids[(position + count - 1) % count].clone().into(),
+                // Self-referential radial ring: a laminar boundary, which is what
+                // a sheet's edges are.
+                radial_next: coedge_ids[position].clone().into(),
+                sense: *sense,
+                pcurves: Vec::new(),
+                use_curve: None,
+                use_curve_parameter_range: None,
+            });
+        }
+        self.ir.model.loops.push(IrLoop {
+            id: loop_id.clone().into(),
+            face: face.into(),
+            boundary_role: role,
+            coedges: coedge_ids.into_iter().map(Into::into).collect(),
+            vertex_uses: Vec::new(),
+        });
+        loop_id
+    }
+
+    /// A one-face body of the given kind, with the loops already built against
+    /// the face id this returns.
+    fn body(&mut self, kind: BodyKind, faces: Vec<IrFace>) -> String {
+        let body = self.id("body");
+        let region = self.id("region");
+        let shell = self.id("shell");
+        let face_ids = faces.iter().map(|face| face.id.clone()).collect();
+        self.ir.model.faces.extend(faces);
+        self.ir.model.shells.push(IrShell {
+            id: shell.clone().into(),
+            region: region.clone().into(),
+            faces: face_ids,
+            wire_edges: Vec::new(),
+            free_vertices: Vec::new(),
+        });
+        self.ir.model.regions.push(Region {
+            id: region.clone().into(),
+            body: body.clone().into(),
+            shells: vec![shell.into()],
+        });
+        self.ir.model.bodies.push(Body {
+            id: body.clone().into(),
+            kind,
+            regions: vec![region.into()],
+            transform: None,
+            name: None,
+            color: None,
+            visible: None,
+        });
+        body
+    }
+
+    fn convert(&self) -> Result<Vec<ImportedBody>> { convert(&self.ir, "TEST") }
+}
+
+/// The z = 0 plane, x-aligned.
+fn xy_plane() -> SurfaceGeometry {
+    SurfaceGeometry::Plane {
+        origin: IrPoint3::new(0.0, 0.0, 0.0),
+        normal: IrVector3::new(0.0, 0.0, 1.0),
+        u_axis: IrVector3::new(1.0, 0.0, 0.0),
+    }
+}
+
+/// An infinite line through `from` towards `to`, parameterised by DISTANCE, so an
+/// edge on it spans `[0, |to - from|]`.
+fn line_through(from: (f64, f64, f64), to: (f64, f64, f64)) -> (CurveGeometry, f64) {
+    let direction = IrVector3::new(to.0 - from.0, to.1 - from.1, to.2 - from.2);
+    let length =
+        (direction.x * direction.x + direction.y * direction.y + direction.z * direction.z).sqrt();
+    (
+        CurveGeometry::Line {
+            origin: IrPoint3::new(from.0, from.1, from.2),
+            direction: IrVector3::new(
+                direction.x / length,
+                direction.y / length,
+                direction.z / length,
+            ),
+        },
+        length,
+    )
+}
+
+/// A triangular sheet face on the z = 0 plane: the smallest thing that is a real
+/// face rather than a fragment.
+fn triangle_sheet() -> Builder {
+    let mut builder = Builder::default();
+    let corners = [(0.0, 0.0), (4.0, 0.0), (0.0, 3.0)];
+    let vertices: Vec<String> = corners
+        .iter()
+        .map(|(x, y)| builder.vertex(*x, *y, 0.0))
+        .collect();
+    let surface = builder.surface(xy_plane());
+    let face_id = builder.id("face");
+    let mut edges = Vec::new();
+    for index in 0..3 {
+        let (from, to) = (corners[index], corners[(index + 1) % 3]);
+        let (geometry, length) = line_through((from.0, from.1, 0.0), (to.0, to.1, 0.0));
+        let curve = builder.curve(geometry);
+        edges.push(builder.edge(
+            Some(&curve),
+            &vertices[index],
+            &vertices[(index + 1) % 3],
+            Some([0.0, length]),
+        ));
+    }
+    let ring = builder.ring(&face_id, LoopBoundaryRole::Outer, &edges);
+    let shell_placeholder = builder.id("shell-unused");
+    builder.body(
+        BodyKind::Sheet,
+        vec![IrFace {
+            id: face_id.into(),
+            // Rewritten by `body`; the shell id is not read by the converter,
+            // which walks body -> region -> shell -> face rather than back up.
+            shell: shell_placeholder.into(),
+            surface: surface.into(),
+            sense: Sense::Forward,
+            loops: vec![ring.into()],
+            name: None,
+            color: None,
+            tolerance: None,
+        }],
+    );
+    builder
+}
+
+// ---------------------------------------------------------------------------
+// The whole path, for the shapes that are supposed to work.
+// ---------------------------------------------------------------------------
+
+/// The end-to-end claim for slices 1 and 2: a decoded sheet face becomes a
+/// compressed shell whose vertices, edges and surface are the ones the document
+/// described.
+#[test]
+fn a_planar_sheet_face_becomes_a_compressed_shell() {
+    let bodies = triangle_sheet().convert().expect("the triangle converts");
+    assert_eq!(bodies.len(), 1);
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        panic!("a sheet body must convert to a sheet, not {:?}", bodies[0]);
+    };
+    assert_eq!(sheet.faces.len(), 1);
+    // Three edges and three vertices, each SHARED: the ring visits vertex 0
+    // twice, once as an end and once as a start, and interning is what makes
+    // those the same index.
+    assert_eq!(sheet.edges.len(), 3);
+    assert_eq!(sheet.vertices.len(), 3);
+    assert_eq!(sheet.faces[0].boundaries.len(), 1);
+    assert_eq!(sheet.faces[0].boundaries[0].len(), 3);
+    assert!(sheet.faces[0].orientation);
+    // The plane is the source plane: normal +z through the origin.
+    let Surface::Plane(plane) = &sheet.faces[0].surface else {
+        panic!(
+            "a plane must convert to a plane, not {:?}",
+            sheet.faces[0].surface
+        );
+    };
+    assert!(plane.normal().z > 0.999, "normal was {:?}", plane.normal());
+    assert!(plane.origin().to_vec().magnitude() < 1.0e-12);
+}
+
+/// The invariant `Edge::try_new` will check later: an edge's curve runs from its
+/// start vertex to its end vertex, at the curve's own parameter bounds.
+///
+/// This is the one that silently breaks if the trim is applied in the wrong frame
+/// or the interval is read as normalised.
+#[test]
+fn every_converted_edge_curve_runs_from_its_start_vertex_to_its_end_vertex() {
+    let bodies = triangle_sheet().convert().expect("the triangle converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    for (index, edge) in sheet.edges.iter().enumerate() {
+        let (front, back) = (
+            sheet.vertices[edge.vertices.0],
+            sheet.vertices[edge.vertices.1],
+        );
+        let (start, end) = edge.curve.range_tuple();
+        assert!(
+            edge.curve.subs(start).distance(front) < 1.0e-9,
+            "edge {index} starts at {:?}, not at its start vertex {front:?}",
+            edge.curve.subs(start)
+        );
+        assert!(
+            edge.curve.subs(end).distance(back) < 1.0e-9,
+            "edge {index} ends at {:?}, not at its end vertex {back:?}",
+            edge.curve.subs(end)
+        );
+    }
+}
+
+/// The strongest oracle available here: monstertruck's OWN extraction accepts the
+/// converted shell.
+///
+/// `Shell::extract` runs `Edge::try_new` on every edge and `Face::try_new` on
+/// every face, so it checks the endpoint agreement and the boundary-wire rules
+/// that the hand-written assertions above only sample. A converter that produced
+/// a plausible-looking shell with a curve running the wrong way, or a ring that
+/// does not close, fails here and passes everything else.
+#[test]
+fn the_converted_shell_is_accepted_by_monstertrucks_own_extraction() {
+    use monstertruck_topology::Shell;
+    let bodies = triangle_sheet().convert().expect("the triangle converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    let shell = Shell::extract(sheet.clone()).expect("the shell extracts");
+    assert_eq!(shell.len(), 1, "one face in, one face out");
+    let face = &shell[0];
+    assert_eq!(face.absolute_boundaries().len(), 1);
+    assert_eq!(face.absolute_boundaries()[0].len(), 3);
+    // A closed ring: `Wire::is_closed` is the property that fails if the coedge
+    // order or an edge's direction was mishandled.
+    assert!(
+        face.absolute_boundaries()[0].is_closed(),
+        "the converted boundary must be a closed wire"
+    );
+}
+
+/// A reversed coedge must show up as an orientation flag, NOT as a reversed curve:
+/// the curve is shared between the faces that meet at the edge, and flipping it
+/// would flip it for both.
+#[test]
+fn a_reversed_coedge_flips_the_edge_use_and_not_the_shared_curve() {
+    let mut builder = Builder::default();
+    let start = builder.vertex(0.0, 0.0, 0.0);
+    let end = builder.vertex(2.0, 0.0, 0.0);
+    let (geometry, length) = line_through((0.0, 0.0, 0.0), (2.0, 0.0, 0.0));
+    let curve = builder.curve(geometry);
+    let edge = builder.edge(Some(&curve), &start, &end, Some([0.0, length]));
+    let surface = builder.surface(xy_plane());
+    let face_id = builder.id("face");
+    // A two-coedge ring over ONE edge: degenerate as a face, but it is the
+    // smallest graph that carries both senses of the same edge.
+    let ring = builder.ring_with_senses(
+        &face_id,
+        LoopBoundaryRole::Outer,
+        &[(edge.clone(), Sense::Forward), (edge, Sense::Reversed)],
+    );
+    let placeholder = builder.id("shell-unused");
+    builder.body(
+        BodyKind::Sheet,
+        vec![IrFace {
+            id: face_id.into(),
+            shell: placeholder.into(),
+            surface: surface.into(),
+            sense: Sense::Forward,
+            loops: vec![ring.into()],
+            name: None,
+            color: None,
+            tolerance: None,
+        }],
+    );
+    let bodies = builder.convert().expect("the two-sense ring converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    assert_eq!(sheet.edges.len(), 1, "one source edge must intern once");
+    let uses = &sheet.faces[0].boundaries[0];
+    assert_eq!(uses.len(), 2);
+    assert!(uses[0].orientation);
+    assert!(!uses[1].orientation);
+    assert_eq!(uses[0].index, uses[1].index);
+    // The shared curve still runs start-to-end, untouched by the reversed use.
+    let (start_parameter, _) = sheet.edges[0].curve.range_tuple();
+    assert!(
+        sheet.edges[0]
+            .curve
+            .subs(start_parameter)
+            .distance(Point3::origin())
+            < 1.0e-12
+    );
+}
+
+/// A face whose sense is reversed becomes a face with `orientation == false`,
+/// which is where `create_face` inverts it. The surface itself must NOT be
+/// pre-inverted, or the two flips cancel.
+#[test]
+fn a_reversed_face_sense_becomes_the_faces_orientation_flag() {
+    let mut builder = triangle_sheet();
+    builder.ir.model.faces[0].sense = Sense::Reversed;
+    let bodies = builder.convert().expect("the triangle converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    assert!(!sheet.faces[0].orientation);
+    let Surface::Plane(plane) = &sheet.faces[0].surface else {
+        unreachable!()
+    };
+    assert!(
+        plane.normal().z > 0.999,
+        "the surface must be untouched; the flip belongs to the face"
+    );
+}
+
+/// The stated outer loop reaches position zero, where `Face::try_new` reads the
+/// outer boundary -- even when the source lists it second.
+#[test]
+fn a_stated_outer_loop_is_moved_to_the_front() {
+    let mut builder = triangle_sheet();
+    // Give the face a second loop, marked inner, and list it FIRST.
+    let inner = {
+        let corners = [(1.0, 1.0), (2.0, 1.0), (1.0, 1.5)];
+        let vertices: Vec<String> = corners
+            .iter()
+            .map(|(x, y)| builder.vertex(*x, *y, 0.0))
+            .collect();
+        let face_id = builder.ir.model.faces[0].id.to_string();
+        let mut edges = Vec::new();
+        for index in 0..3 {
+            let (from, to) = (corners[index], corners[(index + 1) % 3]);
+            let (geometry, length) = line_through((from.0, from.1, 0.0), (to.0, to.1, 0.0));
+            let curve = builder.curve(geometry);
+            edges.push(builder.edge(
+                Some(&curve),
+                &vertices[index],
+                &vertices[(index + 1) % 3],
+                Some([0.0, length]),
+            ));
+        }
+        builder.ring(&face_id, LoopBoundaryRole::Inner, &edges)
+    };
+    let outer = builder.ir.model.faces[0].loops[0].clone();
+    builder.ir.model.faces[0].loops = vec![inner.into(), outer.clone()];
+    let bodies = builder.convert().expect("the two-loop face converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    assert_eq!(sheet.faces[0].boundaries.len(), 2);
+    // Identified by GEOMETRY, not by edge index. Edges are interned in traversal
+    // order, so the inner ring -- listed first by the source -- takes indices 0..3
+    // and the outer one 3..6. Asserting on those numbers would pin the interning
+    // order rather than the loop order, and would read as passing for the wrong
+    // reason.
+    let touches_origin = |boundary: &[CompressedEdgeIndex]| {
+        boundary.iter().any(|use_of| {
+            let edge = &sheet.edges[use_of.index];
+            sheet.vertices[edge.vertices.0].to_vec().magnitude() < 1.0e-12
+                || sheet.vertices[edge.vertices.1].to_vec().magnitude() < 1.0e-12
+        })
+    };
+    // Only the outer triangle has a corner at the origin.
+    assert!(
+        touches_origin(&sheet.faces[0].boundaries[0]),
+        "position zero must hold the loop the source marked outer"
+    );
+    assert!(
+        !touches_origin(&sheet.faces[0].boundaries[1]),
+        "the inner loop must not have been left in front"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Analytic carriers.
+// ---------------------------------------------------------------------------
+
+/// A cylinder must keep its analytic form. Landing it on a spline net is the
+/// silent loss of exactness this converter exists to avoid.
+#[test]
+fn a_cylinder_stays_a_surface_of_revolution() {
+    let mut builder = Builder::default();
+    let surface = builder.surface(SurfaceGeometry::Cylinder {
+        origin: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        radius: 5.0,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let converted = surface::convert(&carrier, &context).expect("a cylinder converts");
+    let Surface::RevolutionSurface(revolution) = &converted else {
+        panic!("a cylinder must stay analytic, got {converted:?}");
+    };
+    // On the surface: every point at parameter (u, v) is `radius` from the axis.
+    for (u, v) in [(0.0, 0.0), (1.0, 0.5), (2.5, 1.0)] {
+        let point = revolution.subs(u, v);
+        let radial = (point.x * point.x + point.y * point.y).sqrt();
+        assert!(
+            (radial - 5.0).abs() < 1.0e-9,
+            "point at ({u}, {v}) sits {radial} from the axis, not 5"
+        );
+    }
+    let _ = surface;
+}
+
+/// A sphere keeps the analytic variant, which is what preserves the closed-form
+/// parameter division -- spec 012 U1.2.
+#[test]
+fn a_sphere_stays_analytic_and_carries_its_radius() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Sphere {
+        center: IrPoint3::new(1.0, -2.0, 3.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        radius: 7.0,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let converted = surface::convert(&carrier, &context).expect("a sphere converts");
+    let Surface::SphericalSurface(sphere) = &converted else {
+        panic!("a sphere must stay analytic, got {converted:?}");
+    };
+    assert_eq!(sphere.entity().radius(), 7.0);
+    assert_eq!(sphere.entity().center(), Point3::new(1.0, -2.0, 3.0));
+}
+
+/// A torus's axis DOES change its point set, so unlike a sphere's the frame has to
+/// survive. Measured on the surface, not on the stored transform.
+#[test]
+fn a_torus_keeps_the_axis_it_was_given() {
+    let mut builder = Builder::default();
+    // Axis along +x, so the tube ring lies in the y-z plane.
+    builder.surface(SurfaceGeometry::Torus {
+        center: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(1.0, 0.0, 0.0),
+        ref_direction: IrVector3::new(0.0, 1.0, 0.0),
+        major_radius: 10.0,
+        minor_radius: 2.0,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let converted = surface::convert(&carrier, &context).expect("a torus converts");
+    let Surface::ToroidalSurface(torus) = &converted else {
+        panic!("a torus must stay analytic, got {converted:?}");
+    };
+    // Every point is `minor` away from the ring of radius `major` in the plane
+    // PERPENDICULAR to +x, which is the claim that the axis was honoured. Were the
+    // axis dropped, the ring would lie in the x-y plane and this would fail.
+    for (u, v) in [(0.0, 0.0), (1.0, 2.0), (3.0, 4.5)] {
+        let point = torus.subs(u, v);
+        let ring_distance = (point.y * point.y + point.z * point.z).sqrt();
+        let to_tube_centre = ((ring_distance - 10.0).powi(2) + point.x * point.x).sqrt();
+        assert!(
+            (to_tube_centre - 2.0).abs() < 1.0e-9,
+            "point at ({u}, {v}) sits {to_tube_centre} from the tube centre, not 2"
+        );
+    }
+}
+
+/// A circular edge becomes an EXACT rational arc between its vertices, at the
+/// angles the file stated.
+#[test]
+fn a_circular_edge_becomes_an_exact_arc_between_its_vertices() {
+    use std::f64::consts::FRAC_PI_2;
+    let geometry = CurveGeometry::Circle {
+        center: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        radius: 3.0,
+    };
+    let ir = empty_document();
+    let context = context_over(&ir);
+    // A quarter turn from the reference direction: (3, 0, 0) to (0, 3, 0).
+    let converted = curve::convert(
+        &geometry,
+        Some([0.0, FRAC_PI_2]),
+        (Point3::new(3.0, 0.0, 0.0), Point3::new(0.0, 3.0, 0.0)),
+        &context,
+    )
+    .expect("a quarter arc converts");
+    let (start, end) = converted.range_tuple();
+    assert!(converted.subs(start).distance(Point3::new(3.0, 0.0, 0.0)) < 1.0e-12);
+    assert!(converted.subs(end).distance(Point3::new(0.0, 3.0, 0.0)) < 1.0e-12);
+    // Exactness, not closeness: a rational quadratic IS a circular arc, so every
+    // interior point is on the circle to floating-point noise and not to a
+    // chordal tolerance.
+    for step in 1..8 {
+        let t = start + (end - start) * f64::from(step) / 8.0;
+        let point = converted.subs(t);
+        let radial = (point.x * point.x + point.y * point.y).sqrt();
+        assert!(
+            (radial - 3.0).abs() < 1.0e-12,
+            "the arc leaves its circle by {} at t = {t}",
+            (radial - 3.0).abs()
+        );
+        assert!(point.z.abs() < 1.0e-12);
+    }
+}
+
+/// A free-form edge is restricted to the knot interval the file stated, and the
+/// restriction keeps the curve's own parameterization.
+#[test]
+fn a_nurbs_edge_is_restricted_to_its_stated_knot_interval() {
+    let geometry = CurveGeometry::Nurbs(IrNurbsCurve {
+        degree: 1,
+        knots: vec![0.0, 0.0, 1.0, 2.0, 2.0],
+        control_points: vec![
+            IrPoint3::new(0.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(2.0, 0.0, 0.0),
+        ],
+        weights: None,
+        periodic: false,
+    });
+    let ir = empty_document();
+    let context = context_over(&ir);
+    let full = curve::convert(
+        &geometry,
+        None,
+        (Point3::origin(), Point3::new(2.0, 0.0, 0.0)),
+        &context,
+    )
+    .expect("the polyline spline converts");
+    assert_eq!(full.range_tuple(), (0.0, 2.0));
+    let restricted = curve::convert(
+        &geometry,
+        Some([0.5, 1.5]),
+        (Point3::new(0.5, 0.0, 0.0), Point3::new(1.5, 0.0, 0.0)),
+        &context,
+    )
+    .expect("the restricted span converts");
+    let (start, end) = restricted.range_tuple();
+    assert!((start - 0.5).abs() < 1.0e-12, "range started at {start}");
+    assert!((end - 1.5).abs() < 1.0e-12, "range ended at {end}");
+    assert!(restricted.subs(start).distance(Point3::new(0.5, 0.0, 0.0)) < 1.0e-12);
+    assert!(restricted.subs(end).distance(Point3::new(1.5, 0.0, 0.0)) < 1.0e-12);
+}
+
+/// An interval that runs BACKWARDS along the carrier gives a curve that still
+/// starts at the edge's start vertex. Leaving this to the coedge's sense would
+/// double-flip the second use of the same edge.
+#[test]
+fn a_backwards_interval_gives_a_curve_that_still_starts_at_the_start_vertex() {
+    let geometry = CurveGeometry::Nurbs(IrNurbsCurve {
+        degree: 1,
+        knots: vec![0.0, 0.0, 1.0, 2.0, 2.0],
+        control_points: vec![
+            IrPoint3::new(0.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(2.0, 0.0, 0.0),
+        ],
+        weights: None,
+        periodic: false,
+    });
+    let ir = empty_document();
+    let context = context_over(&ir);
+    let converted = curve::convert(
+        &geometry,
+        Some([1.5, 0.5]),
+        (Point3::new(1.5, 0.0, 0.0), Point3::new(0.5, 0.0, 0.0)),
+        &context,
+    )
+    .expect("the reversed span converts");
+    let (start, end) = converted.range_tuple();
+    assert!(
+        converted.subs(start).distance(Point3::new(1.5, 0.0, 0.0)) < 1.0e-12,
+        "started at {:?}",
+        converted.subs(start)
+    );
+    assert!(converted.subs(end).distance(Point3::new(0.5, 0.0, 0.0)) < 1.0e-12);
+}
+
+/// A rational free-form curve keeps its weights: the converted control points are
+/// homogeneous, so the curve is the source curve and not its polynomial shadow.
+#[test]
+fn a_rational_nurbs_edge_keeps_its_weights() {
+    use std::f64::consts::FRAC_1_SQRT_2;
+    // The standard rational quadratic quarter circle of radius 1.
+    let geometry = CurveGeometry::Nurbs(IrNurbsCurve {
+        degree: 2,
+        knots: vec![0.0, 0.0, 0.0, 1.0, 1.0, 1.0],
+        control_points: vec![
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 1.0, 0.0),
+            IrPoint3::new(0.0, 1.0, 0.0),
+        ],
+        weights: Some(vec![1.0, FRAC_1_SQRT_2, 1.0]),
+        periodic: false,
+    });
+    let ir = empty_document();
+    let context = context_over(&ir);
+    let converted = curve::convert(
+        &geometry,
+        None,
+        (Point3::new(1.0, 0.0, 0.0), Point3::new(0.0, 1.0, 0.0)),
+        &context,
+    )
+    .expect("the rational quarter circle converts");
+    // If the weights were dropped, the midpoint would be the Bezier midpoint
+    // (0.75, 0.75) at radius 1.06, not on the unit circle.
+    let point = converted.subs(0.5);
+    let radial = (point.x * point.x + point.y * point.y).sqrt();
+    assert!(
+        (radial - 1.0).abs() < 1.0e-12,
+        "the midpoint sits at radius {radial}, so the weights were lost"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Refusals. Every arm below is a path that must FAIL, and be seen to fail.
+// ---------------------------------------------------------------------------
+
+/// The invariant the whole converter is built around: a body it cannot represent
+/// fails the call by name. It is never dropped from the returned list.
+#[test]
+fn a_wire_body_is_refused_by_name_and_not_dropped() {
+    let mut builder = triangle_sheet();
+    // A second body, this one a wire, alongside a sheet that converts fine.
+    builder.body(BodyKind::Wire, Vec::new());
+    let error = builder
+        .convert()
+        .expect_err("a wire body must fail the call");
+    assert!(
+        matches!(error, Error::UnsupportedBodyKind { kind: "wire", .. }),
+        "expected a named wire refusal, got {error}"
+    );
+}
+
+#[test]
+fn a_mixed_dimensional_body_is_refused_by_name() {
+    let mut builder = Builder::default();
+    builder.body(BodyKind::General, Vec::new());
+    let error = builder.convert().expect_err("a general body must fail");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedBodyKind {
+                kind: "mixed-dimensional",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A spindle torus must not reach the analytic variant: its forward map is exact
+/// while `search_parameter` is wrong over roughly a third of the domain, and the
+/// inverse is the direction that places face trims. Spec 011 T1.
+#[test]
+fn a_spindle_torus_is_refused_rather_than_routed_analytically() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Torus {
+        center: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        // Minor exceeds major: the tube swallows the axis and self-intersects.
+        major_radius: 1.0,
+        minor_radius: 4.0,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("a spindle must be refused");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedSurfaceKind {
+                kind: "degenerate torus",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// An elliptical cone is not a surface of revolution, so it must not silently
+/// become the circular cone that `ratio == 1` would have described.
+#[test]
+fn an_elliptical_cone_is_refused_rather_than_rounded_to_a_circular_one() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Cone {
+        origin: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        radius: 2.0,
+        ratio: 0.5,
+        half_angle: 0.3,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("an ellipse must be refused");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedSurfaceKind {
+                kind: "elliptical cone",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A tessellation with a chordal bound must not be presented as exact geometry.
+#[test]
+fn a_source_native_polygonal_surface_is_refused() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Polygonal {
+        vertices: vec![
+            IrPoint3::new(0.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(0.0, 1.0, 0.0),
+        ],
+        triangles: vec![[0, 1, 2]],
+        chordal_deflection: 0.01,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("a mesh must be refused");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedSurfaceKind {
+                kind: "source-native polygonal",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A reference direction parallel to the axis leaves the azimuth undetermined, so
+/// there is no frame to build and no sensible default to pick.
+#[test]
+fn a_degenerate_frame_is_refused_as_malformed() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Cylinder {
+        origin: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(0.0, 0.0, 1.0),
+        radius: 1.0,
+    });
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("a parallel reference must fail");
+    assert!(
+        matches!(error, Error::MalformedGeometry { .. }),
+        "got {error}"
+    );
+}
+
+/// A knot vector that does not match its control net is a defect in the file, and
+/// must not reach `BsplineSurface::new`, which panics on it.
+#[test]
+fn a_nurbs_surface_with_a_short_knot_vector_is_refused_and_does_not_panic() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Nurbs(cadmpeg_ir::geometry::NurbsSurface {
+        u_degree: 1,
+        v_degree: 1,
+        // Both need four knots for two poles at degree one; u gets three.
+        u_knots: vec![0.0, 0.0, 1.0],
+        v_knots: vec![0.0, 0.0, 1.0, 1.0],
+        u_count: 2,
+        v_count: 2,
+        control_points: vec![
+            IrPoint3::new(0.0, 0.0, 0.0),
+            IrPoint3::new(0.0, 1.0, 0.0),
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 1.0, 0.0),
+        ],
+        weights: None,
+        u_periodic: false,
+        v_periodic: false,
+    }));
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("a short knot vector must fail");
+    assert!(
+        matches!(error, Error::MalformedGeometry { .. }),
+        "got {error}"
+    );
+}
+
+/// A periodic net would need control points the file did not send, so it is
+/// refused rather than built with its seam in the wrong place.
+#[test]
+fn a_periodic_nurbs_surface_is_refused() {
+    let mut builder = Builder::default();
+    builder.surface(SurfaceGeometry::Nurbs(cadmpeg_ir::geometry::NurbsSurface {
+        u_degree: 1,
+        v_degree: 1,
+        u_knots: vec![0.0, 1.0, 2.0],
+        v_knots: vec![0.0, 0.0, 1.0, 1.0],
+        u_count: 2,
+        v_count: 2,
+        control_points: vec![
+            IrPoint3::new(0.0, 0.0, 0.0),
+            IrPoint3::new(0.0, 1.0, 0.0),
+            IrPoint3::new(1.0, 0.0, 0.0),
+            IrPoint3::new(1.0, 1.0, 0.0),
+        ],
+        weights: None,
+        u_periodic: true,
+        v_periodic: false,
+    }));
+    let carrier = builder.ir.model.surfaces[0].geometry.clone();
+    let context = context_over(&builder.ir);
+    let error = surface::convert(&carrier, &context).expect_err("a periodic net must fail");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedSurfaceKind {
+                kind: "periodic NURBS",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// An ellipse is exactly representable in principle but has no builder here, so it
+/// is refused by name rather than approximated.
+#[test]
+fn an_elliptical_edge_is_refused_by_name() {
+    let geometry = CurveGeometry::Ellipse {
+        center: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        major_direction: IrVector3::new(1.0, 0.0, 0.0),
+        major_radius: 3.0,
+        minor_radius: 2.0,
+    };
+    let ir = empty_document();
+    let context = context_over(&ir);
+    let error = curve::convert(
+        &geometry,
+        Some([0.0, 1.0]),
+        (Point3::new(3.0, 0.0, 0.0), Point3::new(0.0, 2.0, 0.0)),
+        &context,
+    )
+    .expect_err("an ellipse must be refused");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedCurveKind {
+                kind: "elliptical",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A circle with no stated arc is ambiguous between two arcs, so guessing is
+/// refused.
+#[test]
+fn a_circular_edge_with_no_parameter_range_is_refused() {
+    let geometry = CurveGeometry::Circle {
+        center: IrPoint3::new(0.0, 0.0, 0.0),
+        axis: IrVector3::new(0.0, 0.0, 1.0),
+        ref_direction: IrVector3::new(1.0, 0.0, 0.0),
+        radius: 1.0,
+    };
+    let ir = empty_document();
+    let context = context_over(&ir);
+    let error = curve::convert(
+        &geometry,
+        None,
+        (Point3::new(1.0, 0.0, 0.0), Point3::new(0.0, 1.0, 0.0)),
+        &context,
+    )
+    .expect_err("an untrimmed circle must be refused");
+    assert!(
+        matches!(error, Error::MalformedGeometry { .. }),
+        "got {error}"
+    );
+}
+
+/// An edge with no curve is a tolerant or degenerate edge. Inventing a straight
+/// line between its vertices would put a boundary where the file declined to say
+/// there was one.
+#[test]
+fn an_edge_with_no_curve_is_refused_rather_than_straightened() {
+    let mut builder = triangle_sheet();
+    builder.ir.model.edges[0].curve = None;
+    let error = builder.convert().expect_err("a curveless edge must fail");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedCurveKind {
+                kind: "absent (tolerant or degenerate edge)",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A coedge-local carrier means the two faces at an edge disagree about where it
+/// is, and `CompressedEdge` holds one curve. Keeping either face's version
+/// silently strands the other.
+#[test]
+fn a_coedge_local_carrier_is_refused() {
+    let mut builder = triangle_sheet();
+    let curve = builder.ir.model.curves[0].id.clone();
+    builder.ir.model.coedges[0].use_curve = Some(curve.to_string().into());
+    let error = builder.convert().expect_err("a tolerant coedge must fail");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedCurveKind {
+                kind: "coedge-local (tolerant edge)",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A pole loop is a whole boundary collapsed to one point at a surface
+/// singularity. A ring of edge indices cannot express it.
+#[test]
+fn a_singular_pole_boundary_is_refused() {
+    let mut builder = triangle_sheet();
+    builder.ir.model.loops[0].coedges.clear();
+    let error = builder.convert().expect_err("a pole loop must fail");
+    assert!(
+        matches!(
+            error,
+            Error::UnsupportedSurfaceKind {
+                kind: "singular (pole) face boundary",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+}
+
+/// A reference with no target means the decoded document is not closed. Converting
+/// the closed part of it would hand back a body with a hole in it.
+#[test]
+fn a_dangling_reference_names_the_table_it_dangled_out_of() {
+    let mut builder = triangle_sheet();
+    builder.ir.model.faces[0].surface = "no-such-surface".into();
+    let error = builder.convert().expect_err("a dangling surface must fail");
+    assert!(
+        matches!(
+            error,
+            Error::DanglingReference {
+                kind: "surface",
+                ..
+            }
+        ),
+        "got {error}"
+    );
+    assert!(
+        error.to_string().contains("no-such-surface"),
+        "the message must name the id, got {error}"
+    );
+}
+
+/// A document with no body at all is a fact about the file, reported as such.
+#[test]
+fn an_empty_document_reports_no_geometry() {
+    let ir = empty_document();
+    let error = crate::cadmpeg::to_bodies(&ir, "TEST").expect_err("nothing to convert");
+    assert!(matches!(error, Error::NoGeometry { .. }), "got {error}");
+}
+
+// ---------------------------------------------------------------------------
+// Placement.
+// ---------------------------------------------------------------------------
+
+/// A body's world placement has to be applied. Skipping it puts a
+/// correctly-shaped body at the origin instead of where the assembly says it is,
+/// which is a silent wrong answer rather than a visible failure.
+#[test]
+fn a_body_transform_moves_the_whole_body() {
+    let mut builder = triangle_sheet();
+    let mut transform = cadmpeg_ir::transform::Transform::identity();
+    // Row-major: the translation lives in the last COLUMN, i.e. rows[i][3].
+    transform.rows[0][3] = 10.0;
+    transform.rows[1][3] = 20.0;
+    transform.rows[2][3] = 30.0;
+    builder.ir.model.bodies[0].transform = Some(transform);
+    let bodies = builder.convert().expect("the placed triangle converts");
+    let ImportedBody::Sheet(sheet) = &bodies[0] else {
+        unreachable!()
+    };
+    // The triangle's first corner was the origin.
+    assert!(
+        sheet.vertices[0].distance(Point3::new(10.0, 20.0, 30.0)) < 1.0e-12,
+        "vertex 0 landed at {:?}",
+        sheet.vertices[0]
+    );
+    // And the geometry moved with it, not just the vertices.
+    let Surface::Plane(plane) = &sheet.faces[0].surface else {
+        unreachable!()
+    };
+    assert!((plane.origin().z - 30.0).abs() < 1.0e-12);
+    let (start, _) = sheet.edges[0].curve.range_tuple();
+    assert!(
+        sheet.edges[0]
+            .curve
+            .subs(start)
+            .distance(Point3::new(10.0, 20.0, 30.0))
+            < 1.0e-12
+    );
+}
+
+/// A row-major transform read as column-major transposes every placement, which
+/// for a rotation inverts it. Pinned with an asymmetric matrix, where the two
+/// readings differ.
+#[test]
+fn a_row_major_transform_is_not_read_transposed() {
+    let mut transform = cadmpeg_ir::transform::Transform::identity();
+    // A quarter turn about +z: x -> y, y -> -x. Row-major, that is
+    // rows[0] = [0, -1, 0, 0] and rows[1] = [1, 0, 0, 0].
+    transform.rows[0] = [0.0, -1.0, 0.0, 0.0];
+    transform.rows[1] = [1.0, 0.0, 0.0, 0.0];
+    let matrix = frame::matrix(&transform);
+    let turned = matrix.transform_point(Point3::new(1.0, 0.0, 0.0));
+    assert!(
+        turned.distance(Point3::new(0.0, 1.0, 0.0)) < 1.0e-12,
+        "+x turned to {turned:?}; transposed would give (0, -1, 0)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+
+/// An empty document.
+///
+/// `CadIr` has no `Default`: `empty` takes the document's units, because a
+/// document without them cannot say what its coordinates mean. Millimetres is
+/// what every cadmpeg decoder normalises to.
+fn empty_document() -> cadmpeg_ir::CadIr {
+    cadmpeg_ir::CadIr::empty(cadmpeg_ir::units::Units::default())
+}
+
+/// A conversion context over a document, for the tests that exercise one carrier
+/// rather than a whole body.
+fn context_over(ir: &cadmpeg_ir::CadIr) -> Context<'_> {
+    Context {
+        index: ModelIndex::new(ir),
+        format: "TEST",
+    }
+}

--- a/monstertruck-io/src/cadmpeg/convert/topology.rs
+++ b/monstertruck-io/src/cadmpeg/convert/topology.rs
@@ -1,0 +1,212 @@
+//! Topology: the intermediate representation's entity tables to
+//! [`CompressedShell`].
+//!
+//! Both sides are half-edge B-reps with the same nesting -- body, region, shell,
+//! face, loop, coedge, edge, vertex -- so this is translation from string ids to
+//! array indices, not reconstruction. What it has to get right is orientation and
+//! loop order, because both produce shells that look correct and fail much later.
+//!
+//! # Orientation composes, and each flip is applied exactly once
+//!
+//! Three things flip a boundary in the source: a face's sense against its
+//! surface, a coedge's sense against its edge, and the direction the edge's own
+//! parameter interval runs. They do NOT all belong here:
+//!
+//! * the edge's interval direction is handled where the curve is built
+//!   ([`super::curve`]), so a converted edge curve always runs start vertex to end
+//!   vertex;
+//! * the coedge's sense becomes [`CompressedEdgeIndex::orientation`];
+//! * the face's sense becomes [`CompressedFace::orientation`].
+//!
+//! Applying any of them twice, or in the wrong layer, is the failure mode. The
+//! curve is already oriented by the time this module sees it, so nothing here
+//! re-reads the edge's interval.
+//!
+//! # Loop order
+//!
+//! `Face::try_new` takes the FIRST wire as the outer boundary. The representation
+//! says the first loop is outer "conventionally", and separately carries a
+//! [`LoopBoundaryRole`]. Convention is not a guarantee, so where the role is
+//! stated it is obeyed and the outer loop is moved to the front; where it is not,
+//! the source order stands.
+//!
+//! [`CompressedShell`]: monstertruck_topology::compress::CompressedShell
+//! [`CompressedEdgeIndex::orientation`]: monstertruck_topology::compress::CompressedEdgeIndex
+//! [`CompressedFace::orientation`]: monstertruck_topology::compress::CompressedFace
+
+use std::collections::HashMap;
+
+use cadmpeg_ir::topology::{Face as IrFace, LoopBoundaryRole, Sense, Shell as IrShell};
+use monstertruck_modeling::{Curve, Point3, Surface};
+use monstertruck_topology::compress::{
+    CompressedEdge, CompressedEdgeIndex, CompressedFace, CompressedShell,
+};
+
+use super::{Context, curve, frame, surface};
+use crate::Result;
+
+/// A shell under construction, interning vertices and edges as faces reach them.
+///
+/// Interning is what makes the output a SHARED-edge shell rather than a pile of
+/// independent faces: two faces that use the same source edge get the same index,
+/// which is the property the boolean kernel's topology depends on.
+pub(super) struct ShellBuilder<'a> {
+    context: &'a Context<'a>,
+    vertices: Vec<Point3>,
+    vertex_index: HashMap<String, usize>,
+    edges: Vec<CompressedEdge<Curve>>,
+    edge_index: HashMap<String, usize>,
+    faces: Vec<CompressedFace<Surface>>,
+}
+
+impl<'a> ShellBuilder<'a> {
+    pub(super) fn new(context: &'a Context<'a>) -> Self {
+        Self {
+            context,
+            vertices: Vec::new(),
+            vertex_index: HashMap::new(),
+            edges: Vec::new(),
+            edge_index: HashMap::new(),
+            faces: Vec::new(),
+        }
+    }
+
+    /// Add every face of one source shell.
+    ///
+    /// Several source shells may be added to one builder. That is how a sheet body
+    /// with more than one shell is carried: [`super::ImportedSheet`] is a single
+    /// compressed shell, whose `faces` array is free to hold disconnected
+    /// components, and for a body that bounds no volume the shell partition
+    /// carries no meaning to lose. A SOLID's shells are never merged this way --
+    /// there each one is a separate boundary and the partition is the difference
+    /// between a void and an outer surface.
+    pub(super) fn add_shell(&mut self, shell: &IrShell) -> Result<()> {
+        for face in &shell.faces {
+            let face = self.context.face(face.as_str())?;
+            let face = self.build_face(face)?;
+            self.faces.push(face);
+        }
+        Ok(())
+    }
+
+    pub(super) fn finish(self) -> CompressedShell<Point3, Curve, Surface> {
+        CompressedShell {
+            vertices: self.vertices,
+            edges: self.edges,
+            faces: self.faces,
+            vertex_stable_ids: None,
+            edge_stable_ids: None,
+            face_stable_ids: None,
+        }
+    }
+
+    /// Whether anything was built at all.
+    pub(super) fn is_empty(&self) -> bool { self.faces.is_empty() }
+
+    fn build_face(&mut self, face: &IrFace) -> Result<CompressedFace<Surface>> {
+        let carrier = self.context.surface(face.surface.as_str())?;
+        let surface = surface::convert(&carrier.geometry, self.context)?;
+        let mut boundaries = Vec::with_capacity(face.loops.len());
+        let mut outer = None;
+        for (position, identifier) in face.loops.iter().enumerate() {
+            let ring = self.context.boundary_loop(identifier.as_str())?;
+            if ring.boundary_role == LoopBoundaryRole::Outer && outer.is_none() {
+                outer = Some(position);
+            }
+            let mut edges = Vec::with_capacity(ring.coedges.len());
+            for identifier in &ring.coedges {
+                let coedge = self.context.coedge(identifier.as_str())?;
+                if coedge.use_curve.is_some() {
+                    // A coedge-local 3D carrier means the two faces meeting at
+                    // this edge disagree about where it is. `CompressedEdge` holds
+                    // ONE curve, so admitting this would silently keep one face's
+                    // version and hand the other a boundary it does not lie on.
+                    return Err(crate::Error::UnsupportedCurveKind {
+                        format: self.context.format,
+                        kind: "coedge-local (tolerant edge)",
+                    });
+                }
+                let index = self.intern_edge(coedge.edge.as_str())?;
+                edges.push(CompressedEdgeIndex {
+                    index,
+                    orientation: coedge.sense == Sense::Forward,
+                });
+            }
+            if edges.is_empty() {
+                // A loop with no coedges is a surface singularity carried as
+                // `vertex_uses` -- a pole, where a whole boundary collapses to one
+                // point. monstertruck's compressed boundary is a ring of EDGES
+                // with nowhere to put it.
+                return Err(crate::Error::UnsupportedSurfaceKind {
+                    format: self.context.format,
+                    kind: "singular (pole) face boundary",
+                });
+            }
+            boundaries.push(edges);
+        }
+        if boundaries.is_empty() {
+            return Err(self
+                .context
+                .malformed(format!("face {} carries no boundary loop", face.id)));
+        }
+        // Move the stated outer loop to the front, where `Face::try_new` expects
+        // it. `swap` and not a stable rotation: the inner loops have no order of
+        // their own, so the cheapest correct move is the right one.
+        if let Some(position) = outer {
+            boundaries.swap(0, position);
+        }
+        Ok(CompressedFace {
+            boundaries,
+            orientation: face.sense == Sense::Forward,
+            surface,
+        })
+    }
+
+    /// The index of a source edge in this shell, converting it on first use.
+    fn intern_edge(&mut self, identifier: &str) -> Result<usize> {
+        if let Some(index) = self.edge_index.get(identifier) {
+            return Ok(*index);
+        }
+        let edge = self.context.edge(identifier)?;
+        let front = self.intern_vertex(edge.start.as_str())?;
+        let back = self.intern_vertex(edge.end.as_str())?;
+        let Some(carrier) = &edge.curve else {
+            // An edge with no attributed curve is a tolerant or degenerate edge.
+            // There is no geometry to convert and inventing a line between the
+            // vertices would put a straight boundary where the file declined to
+            // say there was one.
+            return Err(crate::Error::UnsupportedCurveKind {
+                format: self.context.format,
+                kind: "absent (tolerant or degenerate edge)",
+            });
+        };
+        let carrier = self.context.curve(carrier.as_str())?;
+        let curve = curve::convert(
+            &carrier.geometry,
+            edge.param_range,
+            (self.vertices[front], self.vertices[back]),
+            self.context,
+        )?;
+        let index = self.edges.len();
+        self.edges.push(CompressedEdge {
+            vertices: (front, back),
+            curve,
+        });
+        self.edge_index.insert(identifier.to_owned(), index);
+        Ok(index)
+    }
+
+    /// The index of a source vertex in this shell, resolving its point on first
+    /// use.
+    fn intern_vertex(&mut self, identifier: &str) -> Result<usize> {
+        if let Some(index) = self.vertex_index.get(identifier) {
+            return Ok(*index);
+        }
+        let vertex = self.context.vertex(identifier)?;
+        let point = self.context.point(vertex.point.as_str())?;
+        let index = self.vertices.len();
+        self.vertices.push(frame::point(&point.position));
+        self.vertex_index.insert(identifier.to_owned(), index);
+        Ok(index)
+    }
+}

--- a/monstertruck-io/src/cadmpeg/mod.rs
+++ b/monstertruck-io/src/cadmpeg/mod.rs
@@ -26,6 +26,7 @@
 //! [`CompressedShell`]: monstertruck_topology::compress::CompressedShell
 //! [`Surface::Plane`]: monstertruck_modeling::Surface
 
+mod convert;
 pub mod step;
 
 use crate::{Error, Result};
@@ -57,17 +58,22 @@ pub enum ImportedBody {
     Sheet(ImportedSheet),
 }
 
-/// Convert every body in a decoded document into monstertruck solids.
+/// Convert every body in a decoded document into monstertruck bodies.
 ///
 /// Returns [`Error::NoGeometry`] when the document decoded but held no body,
 /// which is a fact about the file, not a failure to read it.
+///
+/// # Every body converts, or the call fails
+///
+/// A returned `Vec` cannot report that one of its entries was left out, so a body
+/// this crate cannot represent fails the whole call and names itself. See the
+/// note on `convert` for why silently returning fewer bodies than the file holds
+/// is the outcome worth failing to avoid.
 pub fn to_bodies(ir: &cadmpeg_ir::CadIr, format: &'static str) -> Result<Vec<ImportedBody>> {
     if ir.model.bodies.is_empty() {
         return Err(Error::NoGeometry { format });
     }
-    Err(Error::Unimplemented {
-        what: "cadmpeg intermediate representation to monstertruck B-rep",
-    })
+    convert::convert(ir, format)
 }
 
 /// Read solids only, discarding sheet bodies.

--- a/monstertruck-io/src/error.rs
+++ b/monstertruck-io/src/error.rs
@@ -49,6 +49,62 @@ pub enum Error {
         kind: &'static str,
     },
 
+    /// The file carried a surface kind with no exact monstertruck equivalent.
+    ///
+    /// Refused rather than approximated. A cone arriving as a spline patch, or a
+    /// source-native triangle soup arriving as a plane, is a loss of exactness
+    /// that the boolean kernel pays for much later and far from here. The caller
+    /// is told which kind was refused so the file can be re-exported in a form
+    /// this crate reads.
+    #[error("{format} carried a {kind} surface, which has no exact monstertruck equivalent")]
+    UnsupportedSurfaceKind {
+        /// Which format was being read.
+        format: &'static str,
+        /// The surface kind cadmpeg reported.
+        kind: &'static str,
+    },
+
+    /// The file carried a curve kind with no exact monstertruck equivalent.
+    ///
+    /// Same reasoning as [`Error::UnsupportedSurfaceKind`].
+    #[error("{format} carried a {kind} curve, which has no exact monstertruck equivalent")]
+    UnsupportedCurveKind {
+        /// Which format was being read.
+        format: &'static str,
+        /// The curve kind cadmpeg reported.
+        kind: &'static str,
+    },
+
+    /// A reference in the decoded graph named an entity the document lacks.
+    ///
+    /// The intermediate representation is a table of entities that refer to each
+    /// other by string id. A reference with no target means the decoded document
+    /// is not closed, so converting the part of it that IS closed would hand back
+    /// a body with holes in it.
+    #[error("{format} referenced a {kind} that the decoded document does not contain: {id}")]
+    DanglingReference {
+        /// Which format was being read.
+        format: &'static str,
+        /// Which entity table the missing target belongs to.
+        kind: &'static str,
+        /// The id that resolved to nothing.
+        id: String,
+    },
+
+    /// Geometry decoded, but its own numbers do not describe a usable shape.
+    ///
+    /// A zero-length axis, a knot vector too short for its control net, a radius
+    /// that is not finite. Separate from [`Error::Decode`]: the bytes parsed and
+    /// the entity is the kind it claims to be, but the values cannot be built
+    /// into geometry.
+    #[error("{format} carried malformed geometry: {detail}")]
+    MalformedGeometry {
+        /// Which format was being read.
+        format: &'static str,
+        /// What is wrong, naming the entity where the converter can.
+        detail: String,
+    },
+
     /// This path is not written yet.
     ///
     /// Present so a placeholder cannot be mistaken for a successful import that


### PR DESCRIPTION
`cadmpeg::to_bodies` returned `Error::Unimplemented` at 0.4.0. The plumbing around it was done -- `iges.rs` decodes through `cadmpeg-codec-iges`, and the API can express sheets as well as solids -- but the intermediate representation never reached a B-rep. It now does, behind the `iges` feature.

## What is in it

`monstertruck-io/src/cadmpeg/convert/`, five modules:

- **`surface.rs`** routes analytic carriers to their ANALYTIC monstertruck variants -- the same routing the STEP loader makes, not a second opinion about it. A sphere or torus landing on its rational net loses the closed-form parameter division, and its `search_parameter` is then wrong in the direction that places face trims (spec 012 U1.2).

  Where the STEP path guards those arms with predicates that restate the net builder's own admissibility rules, this one **probes the builder**. The `iges` feature does not imply `step`, so the STEP guard could not be shared -- and a third copy of a predicate is the thing that drifts. Probing costs one throwaway net per analytic surface and cannot drift. A spindle torus is refused because the builder refuses it, not because this module remembers to.

- **`curve.rs`** converts a carrier FOR an edge, taking the edge's parameter interval with it. The representation stores unbounded carriers, and conic parameters are angles while line parameters are signed distances -- neither normalised. Every arm returns a curve already trimmed and already running start vertex to end vertex, which is what `Edge::try_new` checks.

- **`topology.rs`** interns vertices and edges so two faces sharing a source edge share an index, and applies each orientation flip exactly once: interval direction in the curve, coedge sense as an edge-use flag, face sense as the face's flag.

## Nothing is dropped

A body, surface or curve this crate cannot represent fails the whole call and names itself. A `Vec` cannot say "one of these is missing", and a caller who gets three bodies for a five-body file has no way to find out. Four new typed variants carry those refusals: `UnsupportedSurfaceKind`, `UnsupportedCurveKind`, `DanglingReference`, `MalformedGeometry`. `Error` is `#[non_exhaustive]`, so this is additive.

The IR enums are matched exhaustively with no catch-all, so a cadmpeg release that adds a carrier breaks the build instead of silently refusing at runtime.

## Verification

- 30 converter tests, all passing. Full default `monstertruck-io` suite stays at 111/111.
- Every feature combination checks clean: none, `step`, `cadmpeg`, `iges`, all.
- fmt and clippy clean on the lib.
- The strongest oracle is monstertruck's own `Shell::extract`, which runs `Edge::try_new` and `Face::try_new` over the result.
- Two deliberate mutations -- reading the row-major transform transposed, and dropping the torus's axis -- were each caught by the test that claims to cover them.

Tests build a `CadIr` in memory rather than reading a file: the decoder is cadmpeg's responsibility and is already measured, and a refusal arm needs a carrier no fixture happens to contain.

## What this does NOT show

**Reading an IGES file works.** The repository carries no IGES fixture, so the path from bytes has no test at all.

Also still refused by name, each pending its own work: ellipses, parabolas and hyperbolas (exactly representable, but the geometry crate has a builder only for the circle); composite curves (need the edge split, a topology change); periodic NURBS (need control points the file does not send); pole loops at surface singularities; coedge-local (tolerant) edges.

## Known, pre-existing

`clippy --all-targets` with `iges` but not `step` fails -- the integration tests use `step` unconditionally, since the mt-step fold (8578999e). Not touched here.
