### PR TITLE
docs(io): the IGES section described a placeholder that no longer exists (and hid a red test)

### DIFF
--- a/monstertruck-io/README.md
+++ b/monstertruck-io/README.md
@@ -13,7 +13,7 @@ compiles only the formats it asks for.
 | format | feature | default | state |
 | --- | --- | --- | --- |
 | ISO 10303-21 (STEP) | `step` | yes | read and write, ours |
-| IGES 5.3 | `iges` | no | **placeholder, see below** |
+| IGES 5.3 | `iges` | no | read only, and 5.3 only -- see below |
 
 ```rust
 use monstertruck_io::step::load::{*, step_geometry::*};
@@ -40,17 +40,38 @@ monstertruck reads it correctly, and cadmpeg drops the whole
 `MANIFOLD_SOLID_BREP` because one parameter-space `CIRCLE` fails to decode
 (cadmpeg/cadmpeg#79). Writing STEP is ours outright.
 
-## IGES, and why it refuses
+## IGES: the conversion works, the decoder is the limit
 
-The `iges` feature is a **placeholder**. It decodes a real file with a real
-decoder -- [`cadmpeg`](https://github.com/cadmpeg/cadmpeg), which monstertruck
-has no reason to reimplement -- but the last step, turning the recovered
-geometry into monstertruck's B-rep, is unwritten. So it returns
-`Error::Unimplemented` rather than an empty model, and an empty document
-gets its own `Error::NoGeometry`. A caller therefore cannot mistake "not
-written yet" for "this file contained no geometry". An importer that silently
-returns nothing is worse than one that refuses, and
-`tests/refuses_rather_than_returns_nothing.rs` fails the day it stops.
+Decoding is [`cadmpeg`](https://github.com/cadmpeg/cadmpeg)'s, which
+monstertruck has no reason to reimplement. Turning the recovered geometry into
+monstertruck's B-rep is ours, and it is written: see `cadmpeg` for what
+reaches which surface variant, and why analytic carriers stay analytic.
+
+Measured against `cadmpeg_ir::examples::unit_cube` -- cadmpeg's own document,
+not a hand-built one -- a solid body converts to a shell of 8 vertices, 12
+edges and 6 faces that `monstertruck_topology::Shell::extract` accepts and
+reports CLOSED.
+
+### What still stops a real file
+
+**`cadmpeg-codec-iges` 0.4 decodes IGES 5.3 only.** Older exports are refused
+by the decoder before the converter is reached: measured 2026-08-18, an IGES
+4.0 file and an IGES 5.2 file both return `Error::Decode`. So a failure to
+read an IGES file in the wild is more likely the version ceiling than
+anything here, and no work in this crate moves it.
+
+Carriers this crate refuses on its own are refused BY NAME
+(`Error::UnsupportedSurfaceKind`, `Error::UnsupportedCurveKind`): ellipses
+and the other conics, composite curves, periodic NURBS, pole loops, and
+coedge-local edges.
+
+### Nothing is ever silently empty
+
+A caller cannot mistake any failure for "this file contained no geometry". An
+empty document is `Error::NoGeometry`; a body that cannot be represented
+fails the whole call and names itself, because a returned `Vec` cannot report
+that one of its entries was left out. `Ok(vec![])` is unreachable, and
+`tests/refuses_rather_than_returns_nothing.rs` pins that.
 
 Adding a format is cheap because the cadmpeg codecs all decode into ONE
 intermediate representation, `cadmpeg_ir::CadIr`: the per-format work is only

--- a/monstertruck-io/src/lib.rs
+++ b/monstertruck-io/src/lib.rs
@@ -9,7 +9,7 @@
 //! | format | feature | default | state |
 //! | --- | --- | --- | --- |
 //! | ISO 10303-21 (STEP) | `step` | yes | read and write, ours |
-//! | IGES 5.3 | `iges` | no | **placeholder, see below** |
+//! | IGES 5.3 | `iges` | no | read only, and 5.3 only -- see below |
 //!
 //! ```
 //! use monstertruck_io::step::load::{*, step_geometry::*};
@@ -36,17 +36,38 @@
 //! `MANIFOLD_SOLID_BREP` because one parameter-space `CIRCLE` fails to decode
 //! (cadmpeg/cadmpeg#79). Writing STEP is ours outright.
 //!
-//! # IGES, and why it refuses
+//! # IGES: the conversion works, the decoder is the limit
 //!
-//! The `iges` feature is a **placeholder**. It decodes a real file with a real
-//! decoder -- [`cadmpeg`](https://github.com/cadmpeg/cadmpeg), which monstertruck
-//! has no reason to reimplement -- but the last step, turning the recovered
-//! geometry into monstertruck's B-rep, is unwritten. So it returns
-//! [`Error::Unimplemented`] rather than an empty model, and an empty document
-//! gets its own [`Error::NoGeometry`]. A caller therefore cannot mistake "not
-//! written yet" for "this file contained no geometry". An importer that silently
-//! returns nothing is worse than one that refuses, and
-//! `tests/refuses_rather_than_returns_nothing.rs` fails the day it stops.
+//! Decoding is [`cadmpeg`](https://github.com/cadmpeg/cadmpeg)'s, which
+//! monstertruck has no reason to reimplement. Turning the recovered geometry into
+//! monstertruck's B-rep is ours, and it is written: see [`cadmpeg`] for what
+//! reaches which surface variant, and why analytic carriers stay analytic.
+//!
+//! Measured against `cadmpeg_ir::examples::unit_cube` -- cadmpeg's own document,
+//! not a hand-built one -- a solid body converts to a shell of 8 vertices, 12
+//! edges and 6 faces that [`monstertruck_topology::Shell::extract`] accepts and
+//! reports CLOSED.
+//!
+//! ## What still stops a real file
+//!
+//! **`cadmpeg-codec-iges` 0.4 decodes IGES 5.3 only.** Older exports are refused
+//! by the decoder before the converter is reached: measured 2026-08-18, an IGES
+//! 4.0 file and an IGES 5.2 file both return [`Error::Decode`]. So a failure to
+//! read an IGES file in the wild is more likely the version ceiling than
+//! anything here, and no work in this crate moves it.
+//!
+//! Carriers this crate refuses on its own are refused BY NAME
+//! ([`Error::UnsupportedSurfaceKind`], [`Error::UnsupportedCurveKind`]): ellipses
+//! and the other conics, composite curves, periodic NURBS, pole loops, and
+//! coedge-local edges.
+//!
+//! ## Nothing is ever silently empty
+//!
+//! A caller cannot mistake any failure for "this file contained no geometry". An
+//! empty document is [`Error::NoGeometry`]; a body that cannot be represented
+//! fails the whole call and names itself, because a returned `Vec` cannot report
+//! that one of its entries was left out. `Ok(vec![])` is unreachable, and
+//! `tests/refuses_rather_than_returns_nothing.rs` pins that.
 //!
 //! Adding a format is cheap because the cadmpeg codecs all decode into ONE
 //! intermediate representation, `cadmpeg_ir::CadIr`: the per-format work is only

--- a/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
+++ b/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
@@ -1,22 +1,35 @@
-//! A placeholder importer must REFUSE, not return an empty model.
+//! An importer must never return an empty model where it means something else.
 //!
 //! The failure this guards against is specific: a caller writes
-//! `let solids = iges::from_path(p)?;`, gets `Ok(vec![])`, and concludes the file
+//! `let bodies = iges::from_path(p)?;`, gets `Ok(vec![])`, and concludes the file
 //! held no geometry. That reading is wrong and silent, and it stays wrong until
-//! someone compares against another tool. So while the conversion is unwritten,
-//! every path returns a typed error, and this row fails the day someone
-//! "helpfully" makes it return an empty vector instead.
+//! someone compares against another tool.
+//!
+//! # This file used to assert the opposite
+//!
+//! Until the converter was written it asserted `Error::Unimplemented`, and that
+//! row went **red on master** the day the conversion landed -- unnoticed, because
+//! it is `#![cfg(feature = "iges")]` and the default-feature suite never compiles
+//! it. Its failure message was the good news: *"returned Ok with 1 bodies"*.
+//!
+//! It is kept, rather than deleted, because the invariant it protects is not
+//! about being unimplemented. The two ways to report "nothing" still have to stay
+//! distinguishable from each other and from success, and now there is a third
+//! thing to hold: that a real document converts.
 
 #![cfg(feature = "iges")]
 
 use cadmpeg_ir::{CadIr, examples, units::Units};
-use monstertruck_io::{Error, cadmpeg::to_bodies};
+use monstertruck_io::cadmpeg::{ImportedBody, to_bodies};
+use monstertruck_io::Error;
+use monstertruck_topology::{Shell, shell::ShellCondition};
 
-/// A document with no bodies is a fact about the file, so it gets its own error
-/// rather than the not-implemented one -- otherwise finishing the converter
-/// would silently change what an empty file means.
+/// A document with no bodies is a fact about the file, so it keeps its own error.
+///
+/// This must not collapse into `Ok(vec![])` now that the conversion works: an
+/// empty file and a converted-to-nothing file would then be indistinguishable.
 #[test]
-fn an_empty_document_reports_no_geometry_not_unimplemented() {
+fn an_empty_document_reports_no_geometry_rather_than_an_empty_list() {
     let ir = CadIr::empty(Units::default());
     match to_bodies(&ir, "IGES") {
         Err(Error::NoGeometry { format }) => assert_eq!(format, "IGES"),
@@ -24,22 +37,73 @@ fn an_empty_document_reports_no_geometry_not_unimplemented() {
     }
 }
 
-/// The unwritten conversion must never look like success.
+/// The claim the old row was waiting for: a real intermediate representation
+/// converts into a real solid.
+///
+/// This is stronger evidence than the converter's own unit tests, which build a
+/// `CadIr` by hand and could agree with a shared misreading. `examples::unit_cube`
+/// is **cadmpeg's** document, written by the people who define the format, so it
+/// exercises the graph a decoded file actually produces.
+///
+/// Every number here is checked, not just the body count. A cube is 8 vertices,
+/// 12 edges and 6 faces -- Euler characteristic 2 -- and `Shell::extract` running
+/// `Edge::try_new` and `Face::try_new` over the result reports it CLOSED. A
+/// converter that dropped an edge, or oriented one backwards, gets a body count of
+/// 1 and fails every line below it.
 #[test]
-fn the_unwritten_conversion_refuses() {
-    // A real IR document with actual topology, from cadmpeg's own examples, so
-    // the row exercises the path a decoded file takes rather than a stub.
+fn cadmpegs_own_unit_cube_converts_to_a_closed_solid() {
     let ir = examples::unit_cube();
     assert!(!ir.model.bodies.is_empty(), "the example must carry a body");
-    match to_bodies(&ir, "IGES") {
-        Err(Error::Unimplemented { what }) => {
-            assert!(!what.is_empty(), "the error must name what is missing");
+
+    let bodies = to_bodies(&ir, "IGES").expect("cadmpeg's unit cube must convert");
+    assert_eq!(bodies.len(), 1, "one body in, one body out");
+
+    let ImportedBody::Solid(solid) = &bodies[0] else {
+        panic!("a solid body must convert to a solid, got {:?}", bodies[0]);
+    };
+    assert_eq!(solid.boundaries.len(), 1, "a cube has one boundary shell");
+
+    let shell = &solid.boundaries[0];
+    assert_eq!(shell.vertices.len(), 8, "a cube has 8 vertices");
+    assert_eq!(shell.edges.len(), 12, "a cube has 12 edges, each shared by two faces");
+    assert_eq!(shell.faces.len(), 6, "a cube has 6 faces");
+    // V - E + F = 2. Stated separately: the three counts above could each be
+    // wrong in a way that still looks plausible, and this is the relation that
+    // says they describe a sphere-like surface rather than three numbers.
+    assert_eq!(
+        shell.vertices.len() + shell.faces.len() - shell.edges.len(),
+        2,
+        "Euler characteristic must be 2"
+    );
+
+    let extracted = Shell::extract(shell.clone()).expect("the shell must extract");
+    assert_eq!(extracted.len(), 6);
+    assert_eq!(
+        extracted.shell_condition(),
+        ShellCondition::Closed,
+        "the converted cube must bound a volume; anything less means an edge is \
+         unshared or a boundary does not close"
+    );
+}
+
+/// Success must remain distinguishable from "nothing found".
+///
+/// `to_bodies` returning `Ok(vec![])` should be unreachable -- an empty document
+/// is `NoGeometry`, and a body that cannot convert is a typed refusal naming
+/// itself. This pins that there is no third path that quietly yields an empty
+/// list, which is the shape the whole converter was built to avoid.
+#[test]
+fn no_input_produces_an_empty_ok() {
+    for (name, ir) in [
+        ("empty", CadIr::empty(Units::default())),
+        ("unit cube", examples::unit_cube()),
+    ] {
+        if let Ok(bodies) = to_bodies(&ir, "IGES") {
+            assert!(
+                !bodies.is_empty(),
+                "{name} returned Ok with no bodies -- success and \"found nothing\" must not \
+                 look the same"
+            );
         }
-        Ok(bodies) => panic!(
-            "returned Ok with {} bodies -- a placeholder that reports success is \
-             indistinguishable from a working importer that found nothing",
-            bodies.len()
-        ),
-        other => panic!("expected Unimplemented, got {other:?}"),
     }
 }


### PR DESCRIPTION
`lib.rs` still called the `iges` feature a **placeholder** whose conversion was "unwritten" and which returns `Error::Unimplemented`. That stopped being true at 7916497e (#22). The README is generated from that doc comment and repeated all of it.

## The stale doc was hiding a red test on master

`tests/refuses_rather_than_returns_nothing.rs` asserted `Error::Unimplemented`, and has been **failing on master since #22 merged**:

```
returned Ok with 1 bodies -- a placeholder that reports success is
indistinguishable from a working importer that found nothing
```

**No feature combination in the gate compiles that file.** It is `#![cfg(feature = "iges")]`, so a default-features run skips it entirely; and `--features iges` alone cannot build this crate's test targets at all, because the STEP integration tests and examples use `step` unconditionally. When I verified #22 I ran `cargo check` for the `iges` combination and the lib tests, plus the new `iges_fixtures` target by name — a population that excluded the one file asserting the behaviour I had just changed.

## What the test asserts now

Its failure message was the good news, so the row is inverted rather than deleted:

**`cadmpeg_ir::examples::unit_cube` — cadmpeg's own document, not one of ours — converts to a solid of 8 vertices, 12 edges and 6 faces, Euler characteristic 2, which `Shell::extract` accepts and reports `ShellCondition::Closed`.**

That is stronger evidence than anything in the converter's own unit tests. Those build a `CadIr` by hand and could agree with a shared misreading of the format; this one is written by the people who define it. A converter that dropped an edge or reversed one still returns a body count of 1 while failing every other line.

The invariant the file is named for is unchanged and still pinned: an empty document is `NoGeometry`, a body that cannot convert is a typed refusal naming itself, and `Ok(vec![])` is unreachable.

## Also corrected

The section now leads with the real limit — **`cadmpeg-codec-iges` 0.4 decodes IGES 5.3 only**, measured against a 4.0 file and a 5.2 file — so a reader whose file fails looks at the version before looking here. The format table says "read only, and 5.3 only" instead of "placeholder".

## Verification

- io suite **111/111**, doctests **9/9**.
- The three rows green under `--features iges`.
- README regenerated with `cargo rdme --intralinks-strip-links`; diff is confined to the IGES section and the format table.
- `cargo doc --all-features` adds no new warnings; the 4 remaining sites are pre-existing.

## Worth fixing separately

The gate cannot see `iges`-only tests. The narrow version is one line, since the cfg-gated targets do build in isolation:

```
cargo nextest run -p monstertruck-io --no-default-features --features iges \
    --lib --test refuses_rather_than_returns_nothing
```

The real fix is cfg-gating the STEP integration tests and examples on the `step` feature, so `--features iges` builds the whole crate's targets. I have not touched the gate config here — your call.
