### PR TITLE
feat(geometry): least-squares B-spline fitting, and the solver fix it needs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,5 +101,14 @@ monstertruck-topology = { version = "0.4.0", path = "monstertruck-topology" }
 monstertruck-traits = { version = "0.4.0", path = "monstertruck-traits" }
 
 
+# Build scripts and proc-macro crates otherwise compile with full debug info,
+# and cargo NEVER garbage-collects the old ones: every fingerprint change writes
+# a new `target/debug/build/<crate>/<hash>/` and leaves each earlier hash in
+# place, so the directory grows without bound across ordinary builds and CI runs.
+#
+# Nobody debugs a build script, so this costs nothing.
+[profile.dev.build-override]
+debug = false
+
 [profile.release.package.monstertruck-wasm]
 opt-level = "z"

--- a/TRUCK-PARITY.md
+++ b/TRUCK-PARITY.md
@@ -11,8 +11,11 @@ porting rationale, and the boolean-op regression post-mortem, see
 - Merge-base: `9845ce71` (2026-02-12). **Deliberately never advanced** -- we
   hand-port audited commits rather than merge, so the merge-base is only a
   reference point, not a claim of integration.
-- Last survey: upstream `2bbb4bae` (2026-05-29), 136 commits ahead of the
+- Last survey: upstream `efe39930` (2026-08-31), 178 commits ahead of the
   merge-base.
+- Surveying without a configured remote: `git fetch --no-tags
+  https://github.com/ricosjp/truck.git 'refs/heads/master:refs/truck-survey/master'`
+  leaves the objects in place without adding a remote or a tracking branch.
 - Policy: treat upstream as a patch queue, not a branch to merge. A merge or
   broad cherry-pick would reintroduce upstream's `truck-shapeops` boolean-op
   rewrite that we reverted (it regressed `punched_cube`/`adjacent_cubes_or`),
@@ -59,6 +62,8 @@ has diverged beyond upstream.
 - ported -- `BasisWindow` active-window B-spline basis evaluation (`77e25635`), reimplemented with `SmallVec` and our naming; `BsplineCurve`/`BsplineSurface` evaluate only active control points.
 - ported -- offset geometry (`9031e6dd`): `OffsetCurve`, `OffsetSurface`, `NormalOffsetField`, `CurveScalarFunction`, `SurfaceScalarFunction` (renamed from upstream's `Offset`/`NormalField`/`ScalarFunctionD*`).
 - ported -- `UnitCircle::search_{nearest_}parameter` now honors the `hint` across periods (`f563ae53` + `86e4ed75` clippy), including the `v2` delegations.
+- ported -- least-squares fitting for `BsplineCurve` and `BsplineSurface` (`cd368b72` + `8614ce76` + `cc396e38` + `a696134f`): `BsplineCurve::least_square`, `BsplineSurface::least_square`, at upstream's post-`a696134f` shape with our `KnotVector`/`start_index()`/`values()` naming. Both build the banded normal matrix directly from each sample's `BasisWindow` rather than forming the full design matrix.
+- ported -- the shared `gaussian_elimination` helper's zero-multiplier guards and the back-substitution inner-loop bound (`0..size + 1` -> `i..size + 1`), the remainder of `a696134f`. **Not an accuracy fix.** Graded against an exact rational solve of the same float matrix, the median error ratio is 1.000 across banded, dense-Bernstein and normal-matrix families, with the few differences running in both directions. It does move the refuse-versus-answer boundary, always safely -- the new code leaves the diagonals exactly as `echelon` wrote them, so it can turn a wrong answer into a refusal but not the reverse. No input reachable through `try_interpolate` was found to distinguish the two variants. Taken for parity and because it does strictly less arithmetic.
 - ahead -- `rbf_surface` -> `rolling_ball_fillet`, `af_surface` -> `approximate_fillet_surface` (structure and names diverged; do not resurrect `rbf_surface`).
 - ahead -- `KnotVec` -> `KnotVector`, `BSpline*` -> `Bspline*` spelling.
 - ported -- sphere coordinate-singularity guards (pole `0/0`, `point == center`, `acos` clamp) -- `monstertruck`-only hardening, no upstream equivalent.

--- a/monstertruck-geometry/src/nurbs/bspline_curve.rs
+++ b/monstertruck-geometry/src/nurbs/bspline_curve.rs
@@ -315,6 +315,92 @@ impl<P: ControlPoint<f64>> BsplineCurve<P> {
     pub fn interpole(knot_vec: KnotVector, parameter_points: impl AsMut<[(f64, P)]>) -> Self {
         Self::interpolate(knot_vec, parameter_points)
     }
+
+    /// Fits a B-spline curve to `parameter_points` in the least-squares sense.
+    ///
+    /// Unlike [`try_interpolate`](Self::try_interpolate), which solves a square
+    /// system and passes through every point, this solves the normal equations.
+    /// So it accepts more points than control points and returns the curve that
+    /// minimises the sum of squared distances. Use it to fit sampled or noisy
+    /// data, where an exact interpolant would oscillate.
+    ///
+    /// The normal matrix is banded, because a B-spline basis function is non-zero
+    /// over `degree + 1` spans only. This builds the band directly from each
+    /// sample's [`BasisWindow`] rather than forming the full design matrix, and
+    /// fills both triangles from one pass because the matrix is symmetric.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`Error::GaussianEliminationFailure`] when the normal matrix is
+    /// singular. That happens when a span carries no sample, so the control point
+    /// governing it is unconstrained.
+    ///
+    /// # Examples
+    /// ```
+    /// use monstertruck_geometry::prelude::*;
+    /// use std::f64::consts::TAU;
+    ///
+    /// // Twenty samples of a circle, fitted by eight control points.
+    /// let knot_vec = KnotVector::uniform_knot(2, 6);
+    /// let points = (0..20)
+    ///     .map(|i| {
+    ///         let t = i as f64 / 19.0;
+    ///         (t, Point2::new(f64::cos(TAU * t), f64::sin(TAU * t)))
+    ///     })
+    ///     .collect::<Vec<_>>();
+    /// let curve = BsplineCurve::least_square(knot_vec, 2, &points).unwrap();
+    ///
+    /// // The fit stays near the samples without passing through each one.
+    /// for (t, p) in &points {
+    ///     assert!(curve.subs(*t).distance(*p) < 0.2);
+    /// }
+    /// ```
+    pub fn least_square(
+        knot_vec: KnotVector,
+        degree: usize,
+        parameter_points: &[(f64, P)],
+    ) -> Result<Self> {
+        let n = knot_vec.len() - degree - 1;
+        let mut matrix = vec![vec![0.0; n]; n];
+        let mut rhs = vec![P::origin(); n];
+        for &(t, point) in parameter_points {
+            let basis = knot_vec.bspline_basis_functions(degree, 0, t);
+            let base = basis.start_index();
+            for (local_i, &basis_i) in basis.values().iter().enumerate() {
+                let i = base + local_i;
+                // Skip to `local_i`: the matrix is symmetric, so one pass over
+                // the upper band fills both triangles.
+                for (local_j, &basis_j) in basis.values().iter().enumerate().skip(local_i) {
+                    let j = base + local_j;
+                    let value = basis_i * basis_j;
+                    matrix[i][j] += value;
+                    if i != j {
+                        matrix[j][i] += value;
+                    }
+                }
+                for d in 0..P::DIM {
+                    rhs[i][d] += basis_i * point[d];
+                }
+            }
+        }
+
+        let mut control_points = vec![P::origin(); n];
+        // One solve per coordinate. The matrix is shared, so it is cloned rather
+        // than rebuilt.
+        for d in 0..P::DIM {
+            let mut matrix = matrix.clone();
+            for i in 0..n {
+                matrix[i].push(rhs[i][d]);
+            }
+            let ans = gaussian_elimination::gaussian_elimination(&mut matrix)
+                .ok_or(Error::GaussianEliminationFailure)?;
+            for (v, a) in control_points.iter_mut().zip(ans) {
+                v[d] = a;
+            }
+        }
+
+        Ok(Self::new_unchecked(knot_vec, control_points))
+    }
 }
 
 impl<P> BsplineCurve<P>

--- a/monstertruck-geometry/src/nurbs/bspline_surface/mod.rs
+++ b/monstertruck-geometry/src/nurbs/bspline_surface/mod.rs
@@ -72,6 +72,106 @@ impl<P: ControlPoint<f64>> BsplineSurface<P> {
         }
         true
     }
+
+    /// Fits a B-spline surface to `parameter_points` in the least-squares sense.
+    ///
+    /// The surface counterpart of
+    /// [`BsplineCurve::least_square`](crate::prelude::BsplineCurve::least_square).
+    /// It solves the normal equations, so it accepts more samples than control
+    /// points and returns the surface that minimises the sum of squared
+    /// distances.
+    ///
+    /// The normal matrix is indexed by the flattened control grid, so index `i` is
+    /// `u * v_count + v`. Each sample contributes the outer product of its two
+    /// [`BasisWindow`](crate::prelude::BasisWindow) values. Only the upper band is
+    /// walked, because the matrix is symmetric.
+    ///
+    /// # Failures
+    ///
+    /// Returns [`Error::GaussianEliminationFailure`] when the normal matrix is
+    /// singular, which happens when a patch of the control grid carries no
+    /// sample.
+    ///
+    /// # Examples
+    /// ```
+    /// use monstertruck_geometry::prelude::*;
+    ///
+    /// // Fit a saddle from a 10x10 sample grid onto a 4x4 control grid.
+    /// let knots = (KnotVector::uniform_knot(2, 2), KnotVector::uniform_knot(2, 2));
+    /// let mut points = Vec::new();
+    /// for i in 0..10 {
+    ///     for j in 0..10 {
+    ///         let (u, v) = (i as f64 / 9.0, j as f64 / 9.0);
+    ///         points.push(((u, v), Point3::new(u, v, u * u - v * v)));
+    ///     }
+    /// }
+    /// let surface = BsplineSurface::least_square(knots, (2, 2), &points).unwrap();
+    ///
+    /// for ((u, v), p) in &points {
+    ///     assert!(surface.subs(*u, *v).distance(*p) < 0.05);
+    /// }
+    /// ```
+    pub fn least_square(
+        knot_vecs: (KnotVector, KnotVector),
+        degrees: (usize, usize),
+        parameter_points: &[((f64, f64), P)],
+    ) -> Result<Self> {
+        let (uknot_vec, vknot_vec) = knot_vecs;
+        let (udegree, vdegree) = degrees;
+
+        let ucontrol_count = uknot_vec.len() - udegree - 1;
+        let vcontrol_count = vknot_vec.len() - vdegree - 1;
+        let size = ucontrol_count * vcontrol_count;
+        let mut matrix = vec![vec![0.0; size]; size];
+        let mut rhs = vec![P::origin(); size];
+
+        for &((u, v), point) in parameter_points {
+            let ubasis = uknot_vec.bspline_basis_functions(udegree, 0, u);
+            let vbasis = vknot_vec.bspline_basis_functions(vdegree, 0, v);
+            for (local_ui, &ubasis_i) in ubasis.values().iter().enumerate() {
+                for (local_vi, &vbasis_i) in vbasis.values().iter().enumerate() {
+                    let i = (ubasis.start_index() + local_ui) * vcontrol_count
+                        + vbasis.start_index()
+                        + local_vi;
+                    let basis_i = ubasis_i * vbasis_i;
+                    for (local_uj, &ubasis_j) in ubasis.values().iter().enumerate().skip(local_ui) {
+                        // On the diagonal u-block, start v at `local_vi` so the
+                        // pair is visited once. Off it, the whole v range is new.
+                        let vstart = if local_uj == local_ui { local_vi } else { 0 };
+                        for (local_vj, &vbasis_j) in vbasis.values().iter().enumerate().skip(vstart)
+                        {
+                            let j = (ubasis.start_index() + local_uj) * vcontrol_count
+                                + vbasis.start_index()
+                                + local_vj;
+                            let value = basis_i * ubasis_j * vbasis_j;
+                            matrix[i][j] += value;
+                            if i != j {
+                                matrix[j][i] += value;
+                            }
+                        }
+                    }
+                    for d in 0..P::DIM {
+                        rhs[i][d] += basis_i * point[d];
+                    }
+                }
+            }
+        }
+
+        let mut control_points = vec![vec![P::origin(); vcontrol_count]; ucontrol_count];
+        for d in 0..P::DIM {
+            let mut matrix = matrix.clone();
+            for i in 0..size {
+                matrix[i].push(rhs[i][d]);
+            }
+            let ans = gaussian_elimination::gaussian_elimination(&mut matrix)
+                .ok_or(Error::GaussianEliminationFailure)?;
+            for (point, value) in control_points.iter_mut().flatten().zip(ans) {
+                point[d] = value;
+            }
+        }
+
+        Ok(Self::new_unchecked((uknot_vec, vknot_vec), control_points))
+    }
 }
 
 impl<P: ControlPoint<f64> + Tolerance> BsplineSurface<P> {

--- a/monstertruck-geometry/src/nurbs/mod.rs
+++ b/monstertruck-geometry/src/nurbs/mod.rs
@@ -310,7 +310,10 @@ mod gaussian_elimination {
 
     fn echelon<S: BaseFloat>(matrix: &mut [Vec<S>], i: usize, j: usize) {
         let size = matrix.len();
-        if matrix[i][i] != S::zero() {
+        // The second test skips a row operation whose multiplier is zero. That
+        // operation is a no-op on finite input, so this is work avoided rather
+        // than a result changed.
+        if matrix[i][i] != S::zero() && matrix[j + 1][i] != S::zero() {
             let factor = matrix[j + 1][i] / matrix[i][i];
             (i..size + 1).for_each(|k| {
                 matrix[j + 1][k] = matrix[j + 1][k] - factor * matrix[i][k];
@@ -322,9 +325,15 @@ mod gaussian_elimination {
         let size = matrix.len();
         if matrix[i][i] != S::zero() {
             for j in (1..i + 1).rev() {
-                let factor = matrix[j - 1][i] / matrix[i][i];
-                for k in (0..size + 1).rev() {
-                    matrix[j - 1][k] = matrix[j - 1][k] - factor * matrix[i][k];
+                if matrix[j - 1][i] != S::zero() {
+                    let factor = matrix[j - 1][i] / matrix[i][i];
+                    // `i`, not `0`. Columns left of `i` were already driven to
+                    // zero by `echelon`, so back-substitution has no business
+                    // writing them -- and one of them is `j - 1`, the pivot
+                    // this row is divided by on the way out.
+                    for k in (i..size + 1).rev() {
+                        matrix[j - 1][k] = matrix[j - 1][k] - factor * matrix[i][k];
+                    }
                 }
             }
         }

--- a/monstertruck-geometry/tests/interpolation_and_least_square.rs
+++ b/monstertruck-geometry/tests/interpolation_and_least_square.rs
@@ -1,0 +1,251 @@
+//! Tests for the two `gaussian_elimination` callers.
+//!
+//! Both `BsplineCurve::try_interpolate` and `BsplineCurve::least_square` reach
+//! the same private dense solver in `nurbs::mod`, and before this file neither
+//! had a test -- only doc examples, whose tolerances are loose by design (the
+//! `least_square` example asserts `< 0.2`). That left the solver pinned by
+//! nothing, which matters because it carries no pivoting: its accuracy is a
+//! property of the matrices it happens to be handed, not something the code
+//! defends.
+//!
+//! So these assert the two defining properties at a tolerance tight enough to
+//! move if the solver does, plus both documented refusal paths -- a refusal
+//! that silently became an answer would otherwise be invisible. Every bar below
+//! sits within ~3 orders of the value actually measured, not the 3-to-5 orders
+//! of slack a round number invites.
+//!
+//! What these do NOT constrain, stated so nobody assumes otherwise: they do not
+//! pin the zero-multiplier guards or the back-substitution bound ported from
+//! upstream `a696134f`. Reverting that hunk in full leaves all of them green.
+//! That is not a gap in the tests -- 4,808 probes through this API (degrees 2-7,
+//! random and equispaced parameters, near-duplicate separations of one ulp,
+//! 5e-17, 1e-16, 1e-15, and exact duplicates) produce an identical
+//! refuse/answer outcome on both variants. No input reachable through this
+//! surface distinguishes them, so no test here can.
+
+use monstertruck_geometry::prelude::*;
+
+/// `uniform_knot(degree, division)` yields `degree + division` control points.
+/// Asserted rather than assumed, because every size below is derived from it.
+#[test]
+fn uniform_knot_control_point_count() {
+    let knot_vec = KnotVector::uniform_knot(3, 5);
+    assert_eq!(knot_vec.len(), 12);
+    assert_eq!(knot_vec.len() - 3 - 1, 8);
+}
+
+fn sample_curve() -> BsplineCurve<Point3> {
+    BsplineCurve::new(
+        KnotVector::uniform_knot(3, 5),
+        vec![
+            Point3::new(0.0, 0.0, 0.0),
+            Point3::new(1.0, 2.0, -1.0),
+            Point3::new(3.0, -1.0, 2.0),
+            Point3::new(4.0, 4.0, 1.0),
+            Point3::new(6.0, 0.5, -2.0),
+            Point3::new(7.0, -3.0, 3.0),
+            Point3::new(9.0, 1.0, 0.5),
+            Point3::new(10.0, 2.5, -1.5),
+        ],
+    )
+}
+
+/// The defining property of interpolation: the curve passes through every point
+/// it was given.
+#[test]
+fn interpolation_passes_through_every_point() {
+    let knot_vec = KnotVector::uniform_knot(3, 5);
+    let points = [
+        (0.0, Point3::new(1.0, 2.0, 3.0)),
+        (0.15, Point3::new(4.0, -1.0, 10.0)),
+        (0.3, Point3::new(-3.0, 5.0, 6.0)),
+        (0.45, Point3::new(6.0, 2.0, 12.0)),
+        (0.6, Point3::new(0.0, -4.0, 1.0)),
+        (0.75, Point3::new(8.0, 3.0, -2.0)),
+        (0.9, Point3::new(2.0, 7.0, 5.0)),
+        (1.0, Point3::new(-1.0, 0.0, 9.0)),
+    ];
+    let curve = BsplineCurve::try_interpolate(knot_vec, points).unwrap();
+
+    // Reported as the worst of the eight rather than asserted point by point,
+    // so a failure says how far off the solver is and not merely that it is.
+    let worst = points
+        .iter()
+        .map(|&(t, p)| curve.subs(t).distance(p))
+        .fold(0.0f64, f64::max);
+    assert!(
+        worst < 1.0e-12,
+        "interpolant misses its own points by {worst:.3e}"
+    );
+}
+
+/// Least squares over data drawn from a curve that already lies in the fit
+/// space has an exact answer -- the original control points -- so this grades
+/// the solver against a known truth rather than against a loose band.
+#[test]
+fn least_square_recovers_an_exactly_representable_curve() {
+    let original = sample_curve();
+    let samples = (0..40)
+        .map(|i| {
+            let t = i as f64 / 39.0;
+            (t, original.subs(t))
+        })
+        .collect::<Vec<_>>();
+
+    let fit = BsplineCurve::least_square(KnotVector::uniform_knot(3, 5), 3, &samples).unwrap();
+
+    let worst = (0..8)
+        .map(|i| fit.control_point(i).distance(*original.control_point(i)))
+        .fold(0.0f64, f64::max);
+    assert!(
+        worst < 1.0e-11,
+        "least squares missed the exact answer by {worst:.3e} in control-point distance"
+    );
+}
+
+/// The overdetermined case with noise: not an exact-recovery question, only
+/// that the normal equations are actually solved and the fit tracks the data.
+#[test]
+fn least_square_fits_perturbed_samples() {
+    let original = sample_curve();
+    let samples = (0..60)
+        .map(|i| {
+            let t = i as f64 / 59.0;
+            // Deterministic, mean-ish-zero wobble; no RNG, so this cannot flake.
+            let wobble = 0.05 * f64::sin(37.0 * t) * f64::cos(11.0 * t);
+            let p = original.subs(t);
+            (t, Point3::new(p.x + wobble, p.y - wobble, p.z + wobble))
+        })
+        .collect::<Vec<_>>();
+
+    let fit = BsplineCurve::least_square(KnotVector::uniform_knot(3, 5), 3, &samples).unwrap();
+
+    let worst = samples
+        .iter()
+        .map(|&(t, p)| fit.subs(t).distance(p))
+        .fold(0.0f64, f64::max);
+    assert!(worst < 0.1, "fit strayed from its samples by {worst:.3e}");
+}
+
+/// Duplicate parameters make two rows identical, so the system is singular.
+/// This is the path where a solver that quietly perturbs its own pivots would
+/// answer instead of refusing, which is strictly worse than refusing.
+#[test]
+fn interpolation_refuses_on_duplicate_parameters() {
+    let knot_vec = KnotVector::uniform_knot(3, 5);
+    let points = [
+        (0.0, Point3::new(1.0, 2.0, 3.0)),
+        (0.15, Point3::new(4.0, -1.0, 10.0)),
+        (0.3, Point3::new(-3.0, 5.0, 6.0)),
+        // Same parameter as the row above, different point.
+        (0.3, Point3::new(6.0, 2.0, 12.0)),
+        (0.6, Point3::new(0.0, -4.0, 1.0)),
+        (0.75, Point3::new(8.0, 3.0, -2.0)),
+        (0.9, Point3::new(2.0, 7.0, 5.0)),
+        (1.0, Point3::new(-1.0, 0.0, 9.0)),
+    ];
+    assert!(
+        BsplineCurve::try_interpolate(knot_vec, points).is_err(),
+        "a singular interpolation system was answered rather than refused"
+    );
+}
+
+/// `least_square`'s documented failure: a span with no sample leaves its
+/// control point unconstrained, so the normal matrix is singular.
+#[test]
+fn least_square_refuses_when_a_span_carries_no_sample() {
+    // Every sample crowded into the first half, so the last spans are empty.
+    let original = sample_curve();
+    let samples = (0..30)
+        .map(|i| {
+            let t = 0.3 * i as f64 / 29.0;
+            (t, original.subs(t))
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        BsplineCurve::least_square(KnotVector::uniform_knot(3, 5), 3, &samples).is_err(),
+        "an unconstrained control point was fitted rather than refused"
+    );
+}
+
+/// The third `gaussian_elimination` call site. Its only prior coverage was a doc
+/// example, and this repo's `.config/nextest.toml` says nextest does not run
+/// doctests -- so a change to the shared solver could not reach it from the
+/// test runner at all.
+///
+/// The saddle `u^2 - v^2` lies exactly in the biquadratic span being fitted, so
+/// unlike the doc example's `< 0.05` this can demand machine precision.
+#[test]
+fn surface_least_square_recovers_an_exactly_representable_saddle() {
+    let knots = (
+        KnotVector::uniform_knot(2, 2),
+        KnotVector::uniform_knot(2, 2),
+    );
+    let mut points = Vec::new();
+    for i in 0..10 {
+        for j in 0..10 {
+            let (u, v) = (i as f64 / 9.0, j as f64 / 9.0);
+            points.push(((u, v), Point3::new(u, v, u * u - v * v)));
+        }
+    }
+    let surface = BsplineSurface::least_square(knots, (2, 2), &points).unwrap();
+
+    let worst = points
+        .iter()
+        .map(|((u, v), p)| surface.subs(*u, *v).distance(*p))
+        .fold(0.0f64, f64::max);
+    assert!(
+        worst < 1.0e-12,
+        "surface fit missed an exactly representable saddle by {worst:.3e}"
+    );
+}
+
+/// Everything above rides on one matrix shape (degree 3, 8 control points).
+/// The solver's accuracy is a property of the matrix it is handed, so a single
+/// shape is a single observation. Degrees 2 and 5 are banded like it; the Bezier
+/// knot vector is not banded at all -- its basis is Bernstein and the matrix is
+/// dense, which is the shape `monstertruck-fillet` drives through
+/// `composite_line_bezier`.
+#[test]
+fn interpolation_holds_across_degrees_and_a_dense_bezier_basis() {
+    for degree in [2usize, 5] {
+        let n = degree + 5;
+        let knot_vec = KnotVector::uniform_knot(degree, n - degree);
+        let pts: Vec<(f64, Point3)> = (0..n)
+            .map(|i| {
+                let t = i as f64 / (n - 1) as f64;
+                (t, Point3::new(3.0 * t, f64::sin(4.0 * t), t * t - 1.0))
+            })
+            .collect();
+        let curve = BsplineCurve::try_interpolate(knot_vec, pts.clone()).unwrap();
+        let worst = pts
+            .iter()
+            .map(|&(t, p)| curve.subs(t).distance(p))
+            .fold(0.0f64, f64::max);
+        assert!(
+            worst < 1.0e-13,
+            "banded degree {degree} interpolant misses its points by {worst:.3e}"
+        );
+    }
+
+    for degree in [3usize, 6] {
+        let knot_vec = KnotVector::bezier_knot(degree);
+        let n = degree + 1;
+        let pts: Vec<(f64, Point3)> = (0..n)
+            .map(|i| {
+                let t = i as f64 / (n - 1) as f64;
+                (t, Point3::new(2.0 * t, 1.0 - t, f64::cos(3.0 * t)))
+            })
+            .collect();
+        let curve = BsplineCurve::try_interpolate(knot_vec, pts.clone()).unwrap();
+        let worst = pts
+            .iter()
+            .map(|&(t, p)| curve.subs(t).distance(p))
+            .fold(0.0f64, f64::max);
+        assert!(
+            worst < 1.0e-13,
+            "dense Bernstein degree {degree} interpolant misses its points by {worst:.3e}"
+        );
+    }
+}

--- a/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
+++ b/monstertruck-io/tests/refuses_rather_than_returns_nothing.rs
@@ -20,8 +20,8 @@
 #![cfg(feature = "iges")]
 
 use cadmpeg_ir::{CadIr, examples, units::Units};
-use monstertruck_io::cadmpeg::{ImportedBody, to_bodies};
 use monstertruck_io::Error;
+use monstertruck_io::cadmpeg::{ImportedBody, to_bodies};
 use monstertruck_topology::{Shell, shell::ShellCondition};
 
 /// A document with no bodies is a fact about the file, so it keeps its own error.
@@ -65,7 +65,11 @@ fn cadmpegs_own_unit_cube_converts_to_a_closed_solid() {
 
     let shell = &solid.boundaries[0];
     assert_eq!(shell.vertices.len(), 8, "a cube has 8 vertices");
-    assert_eq!(shell.edges.len(), 12, "a cube has 12 edges, each shared by two faces");
+    assert_eq!(
+        shell.edges.len(),
+        12,
+        "a cube has 12 edges, each shared by two faces"
+    );
     assert_eq!(shell.faces.len(), 6, "a cube has 6 faces");
     // V - E + F = 2. Stated separately: the three counts above could each be
     // wrong in a way that still looks plausible, and this is the relation that


### PR DESCRIPTION
Upstream truck grew least-squares fitting for B-spline curves and surfaces (`cd368b72`, `8614ce76`, `cc396e38`, `a696134f`). **This repository never got it.** It has `try_interpolate`, which solves a square system and passes through every point, and nothing that fits more samples than control points.

```rust
BsplineCurve::least_square(knot_vec, degree, &[(t, point), ..])
BsplineSurface::least_square((uknots, vknots), (udeg, vdeg), &[((u, v), p), ..])
```

Both solve the normal equations. The matrix is banded — a B-spline basis function is non-zero over `degree + 1` spans only — so both build the band directly from each sample's `BasisWindow` rather than forming the full design matrix, and fill both triangles in one pass because it is symmetric. Both refuse with `Error::GaussianEliminationFailure` when a span (or, for the surface, a patch of the control grid) carries no sample, since the control point governing it is then unconstrained.

## The rest of `a696134f`, which is not an accuracy fix

The same upstream commit also changed the shared `gaussian_elimination` helper: two zero-multiplier guards, and a back-substitution inner-loop bound moved from `0..size + 1` to `i..size + 1`. That bound *looks* like it should matter, because the loop writes column `j - 1` of row `j - 1` — the pivot that row is later divided by.

Measured before taking it, by transcribing both variants to float and grading them against an exact rational solve of the same matrix:

- median error ratio **1.000** across banded, dense-Bernstein and normal-matrix families, with the few differences running in **both** directions;
- it *does* move the refuse-versus-answer boundary, and only ever safely — the new code leaves the diagonals exactly as `echelon` wrote them, so it can convert a wrong answer into a refusal but never the reverse;
- **no input reachable through `try_interpolate` was found that distinguishes the two variants.**

Taken for parity and because it does strictly less arithmetic. It repairs no demonstrated defect, and the parity table says so rather than implying a fix.

## Tests, because the solver had none

Neither `try_interpolate` nor the new pair had a test. This solver carries **no pivoting**, so its accuracy is a property of whatever matrix it is handed rather than something the code defends — and nothing was pinning that.

Eight tests: interpolation through its own points; curve and surface least squares each recovering something that lies exactly in the fit space, graded against known control points; an overdetermined noisy fit; both documented refusal paths; and degree 2/5 plus a dense Bezier knot vector, so the suite does not rest on a single matrix shape. Bars sit within ~3 orders of the measured values rather than at round numbers.

Each was checked to be *capable of failing*: deleting back-substitution reds the three accuracy tests (worst `7.352e0` in control-point distance), and disabling the zero-diagonal refusal reds exactly the two refusal tests.

## Also

`[profile.dev.build-override] debug = false`. Build scripts compile with full debug info by default and cargo never garbage-collects the old ones, so `target/debug/build/<crate>/<hash>/` grows without bound across ordinary builds. Nobody debugs a build script.

## Gates

| gate | result |
|---|---|
| `cargo nextest run -p monstertruck-geometry` | 229 passed, 1 skipped |
| `cargo test --doc -p monstertruck-geometry` | 158 passed |
| `cargo +nightly fmt --check` | clean for every file in this diff |
| `clippy -p monstertruck-geometry --all-targets -D warnings` | clean |

**Two failures on this branch are pre-existing on master and are not touched here** — both verified byte-identical to `origin/master`:

- `cargo +nightly fmt --check` reports drift in `monstertruck-io/tests/refuses_rather_than_returns_nothing.rs`
- clippy errors on `monstertruck-core/src/derivatives.rs:870` — *"the loop variable `n` is used to index `res[m]`"*

Neither is in this diff. They mean master is currently not fmt-clean and not clippy-clean, which is worth a separate fix.
